### PR TITLE
Fix ChartMuseum push: CHARTMUSEUM_USER is a variable, not a secret

### DIFF
--- a/.github/workflows/runtz-pipeline-prod-k8s.yml
+++ b/.github/workflows/runtz-pipeline-prod-k8s.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Lint, package and push chart to ChartMuseum
         env:
-          CHARTMUSEUM_USER: ${{ secrets.CHARTMUSEUM_USER }}
+          CHARTMUSEUM_USER: ${{ vars.CHARTMUSEUM_USER }}
           CHARTMUSEUM_PASSWORD: ${{ secrets.CHARTMUSEUM_PASSWORD }}
         run: ./scripts/helm-release.sh
 


### PR DESCRIPTION
Fixes the prod pipeline reading `secrets.CHARTMUSEUM_USER` when that value is configured as an org **variable** (`vars.CHARTMUSEUM_USER = runtz`), same pattern as `DOCKER_LOGIN`. This was causing the chart push to ChartMuseum to send no auth at all.