### PR TITLE
Fix /install.sh ingress path: use Prefix, not Exact

### DIFF
--- a/helm/environments/dev/values.yaml
+++ b/helm/environments/dev/values.yaml
@@ -85,8 +85,11 @@ ingress:
           servicePort: 3000
         # CLI installer (curl -fsSL https://runtz.dev/install.sh | bash); the
         # landing app's proxy 302-redirects it to the raw script on GitHub.
+        # pathType must be Prefix: the cloudflare-tunnel-ingress-controller
+        # does not support Exact and silently drops the whole Ingress's DNS
+        # record if any path uses it.
         - path: /install.sh
-          pathType: Exact
+          pathType: Prefix
           serviceName: runtz-landing
           servicePort: 3000
         - path: /login

--- a/helm/environments/prod/values.yaml
+++ b/helm/environments/prod/values.yaml
@@ -82,8 +82,11 @@ ingress:
           servicePort: 3000
         # CLI installer (curl -fsSL https://runtz.dev/install.sh | bash); the
         # landing app's proxy 302-redirects it to the raw script on GitHub.
+        # pathType must be Prefix: the cloudflare-tunnel-ingress-controller
+        # does not support Exact and silently drops the whole Ingress's DNS
+        # record if any path uses it.
         - path: /install.sh
-          pathType: Exact
+          pathType: Prefix
           serviceName: runtz-landing
           servicePort: 3000
         - path: /login


### PR DESCRIPTION
## Summary
`pathType: Exact` on the `/install.sh` ingress path broke the `cloudflare-tunnel-ingress-controller`'s ability to parse the whole `runtz-frontend` Ingress in both `dev` and `prod`, which deleted the `runtz.dev` / `runtz-dev.runtz.dev` DNS records entirely (both hosts went down). Switched to `Prefix`, which the controller supports. Already hotfixed live via manual `helm upgrade` in both namespaces to restore service immediately; this PR brings `main` back in line with what's deployed.

## Test plan
- [x] Confirmed via controller logs: no more "path type ... Exact ... not supported" errors after the fix
- [x] `dig runtz.dev` / `dig runtz-dev.runtz.dev` CNAME resolve again
- [x] `curl -fsSL https://runtz.dev/install.sh` and the dev equivalent both 302 correctly to the raw script

🤖 Generated with [Claude Code](https://claude.com/claude-code)