### PR TITLE
Remove both operator secrets and make sessions revocable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,8 @@
-# Copy this file to .env and fill the required values before starting.
-# Required secrets (the engine refuses to start with empty or placeholder values):
-#   JWT_SECRET          generate with: openssl rand -base64 32
-#   RUNTZ_INGEST_TOKEN  generate with: openssl rand -base64 24
+# Everything here is optional: `docker compose up -d` works with no .env at
+# all. Copy this file only to change ports or enable OAuth/email login.
 PORT=8080
 MONGODB_URI=mongodb://mongodb:27017
 MONGODB_DATABASE=runtz
-JWT_SECRET=
-RUNTZ_INGEST_TOKEN=
 RUNTZ_DEPLOYMENT_MODE=self-hosted
 RUNTZ_PUBLIC_URL=http://localhost:3000
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,42 @@ Until `1.0.0` ships, public builds are tagged as release candidates
 
 ## [Unreleased]
 
+### Removed
+
+- **Breaking:** `JWT_SECRET` and `RUNTZ_INGEST_TOKEN` no longer exist. Both
+  `docker compose up -d` and `helm install` now run with no secrets at all —
+  browser sessions, API keys and email login codes are issued and stored by the
+  engine. Existing deployments can drop both variables; they are ignored.
+- **Breaking:** the ingest endpoints (`POST /api/v1/ingest/*`) require an API
+  key. Set `RUNTZ_TOKEN` in CI to an `rtz_...` key created in **Settings → API
+  keys**. The workspace now always comes from the key, so `workspaceId` /
+  `workspace` in the request body are accepted and ignored — a key issued for
+  one workspace can no longer write into another.
+
+### Added
+
+- `POST /api/v1/auth/logout` ends a session server-side; signing out now
+  actually revokes, rather than only forgetting the token client-side.
+- Password login is rate limited: ten wrong passwords lock the username for an
+  hour, reusing the lockout that already guarded email login codes.
+
+### Changed
+
+- **Breaking:** browser sessions moved from a JWT in `localStorage` to an
+  opaque token in an `HttpOnly`, `SameSite=Lax` cookie, stored as a SHA-256
+  hash in a new `sessions` collection with a TTL index. Script injected into
+  the dashboard can no longer read the session, and a leaked session can be
+  revoked. Everyone is signed out once on upgrade.
+- In cloud mode the `admin` role no longer widens access to data. It still
+  gates administration (users, workspaces, licensing), but scans, workspaces,
+  usage and API keys stay scoped to the workspaces a user belongs to, so one
+  tenant's source-code findings are not reachable from another.
+- Email login codes are hashed with bcrypt instead of HMAC-SHA256, which
+  removed the last use of `JWT_SECRET` while keeping a six-digit code
+  impractical to reverse from a database dump.
+- The compose file no longer publishes MongoDB on `27017`; only the backend
+  reaches it, over the compose network.
+
 ## [1.0.0-rc5] - 2026-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -69,8 +69,6 @@ Uses the published images (`runtzdev/runtz-engine`, `runtzdev/runtz-frontend`):
 ```bash
 git clone https://github.com/runtz-dev/runtz
 cd runtz
-cp .env.example .env
-# fill JWT_SECRET (openssl rand -base64 32) and RUNTZ_INGEST_TOKEN (openssl rand -base64 24)
 docker compose up -d
 ```
 
@@ -105,10 +103,7 @@ automatically through the fixed central engine at `https://engine.runtz.dev`.
 helm repo add runtz https://helm.runtz.dev
 helm repo update
 
-cp helm/runtz/values.secrets.example.yaml values.secrets.yaml
-# fill jwtSecret and ingestToken
-
-helm install runtz runtz/runtz -f values.secrets.yaml
+helm install runtz runtz/runtz
 ```
 
 Non-secret config lives in the chart values and is rendered as ConfigMaps;
@@ -143,8 +138,7 @@ Backend engine:
 ```bash
 cd engine
 go test ./...
-JWT_SECRET=$(openssl rand -base64 32) RUNTZ_INGEST_TOKEN=$(openssl rand -base64 24) \
-  go run ./cmd/server
+go run ./cmd/server
 ```
 
 Frontend:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,9 +32,11 @@ fixes. After `1.0.0`, we will support the latest minor release.
 
 ## Scope notes
 
-- The Platform ships with secure-by-default settings: the engine refuses to
-  start with missing or placeholder `JWT_SECRET` / `RUNTZ_INGEST_TOKEN`
-  values. Reports about deployments that deliberately weaken these controls
-  are out of scope.
+- The Platform ships with secure-by-default settings and needs no operator
+  secrets at all: browser sessions, API keys and email login codes are issued
+  and stored by the engine, so there is no shared signing key or ingest token
+  to leak, default or forget to rotate. Sessions live in HttpOnly cookies and
+  are revocable server-side. Reports about deployments that deliberately weaken
+  these controls are out of scope.
 - Vulnerabilities in third-party dependencies should also be reported
   upstream; we still want to know so we can ship updated builds.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 # runtz self-hosted stack (published images).
 #
-#   cp .env.example .env   # then fill JWT_SECRET and RUNTZ_INGEST_TOKEN
 #   docker compose up -d
+#
+# No secrets to set: sessions, API keys and login codes are issued and stored
+# by the engine. Copy .env.example to .env only to change ports or add OAuth.
 #
 # To build from source instead, add the dev override:
 #   docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
@@ -10,8 +12,9 @@ services:
     image: mongo:7
     container_name: runtz-mongodb
     restart: unless-stopped
-    ports:
-      - "${MONGODB_PORT:-27017}:27017"
+    # Deliberately not published to the host: the database holds every session
+    # and scan, and only the backend needs to reach it over the compose network.
+    # For a one-off shell use `docker compose exec mongodb mongosh`.
     volumes:
       - mongodb-data:/data/db
     healthcheck:
@@ -31,8 +34,6 @@ services:
       PORT: ${PORT:-8080}
       MONGODB_URI: ${MONGODB_URI:-mongodb://mongodb:27017}
       MONGODB_DATABASE: ${MONGODB_DATABASE:-runtz}
-      JWT_SECRET: "${JWT_SECRET:?Set JWT_SECRET in .env (generate with openssl rand -base64 32)}"
-      RUNTZ_INGEST_TOKEN: "${RUNTZ_INGEST_TOKEN:?Set RUNTZ_INGEST_TOKEN in .env (generate with openssl rand -base64 24)}"
       RUNTZ_DEPLOYMENT_MODE: ${RUNTZ_DEPLOYMENT_MODE:-self-hosted}
       RUNTZ_PUBLIC_URL: ${RUNTZ_PUBLIC_URL:-http://localhost:3000}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}

--- a/engine/internal/api/access_test.go
+++ b/engine/internal/api/access_test.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/runtz-dev/runtz/engine/internal/config"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func TestGlobalDataScopeIsSelfHostedAdminOnly(t *testing.T) {
+	admin := User{Role: "admin"}
+	member := User{Role: "member"}
+
+	selfHosted := &Server{cfg: config.Config{DeploymentMode: hostingSelfHosted}}
+	if !selfHosted.globalDataScope(admin) {
+		t.Fatal("self-hosted admin should read across every workspace")
+	}
+	if selfHosted.globalDataScope(member) {
+		t.Fatal("self-hosted member should be limited to their workspaces")
+	}
+
+	// In cloud each workspace is a different customer, so no role widens data
+	// access: an admin row appearing in the database must not expose tenants
+	// to each other.
+	cloud := &Server{cfg: config.Config{DeploymentMode: hostingCloud}}
+	if cloud.globalDataScope(admin) {
+		t.Fatal("cloud admin must not read across tenants")
+	}
+	if cloud.globalDataScope(member) {
+		t.Fatal("cloud member must not read across tenants")
+	}
+}
+
+func TestUserCanAccessWorkspaceHonoursDeploymentMode(t *testing.T) {
+	own := bson.NewObjectID()
+	other := bson.NewObjectID()
+	admin := User{Role: "admin", WorkspaceIDs: []bson.ObjectID{own}}
+
+	selfHosted := &Server{cfg: config.Config{DeploymentMode: hostingSelfHosted}}
+	if !selfHosted.userCanAccessWorkspace(admin, other) {
+		t.Fatal("self-hosted admin should reach a workspace they do not belong to")
+	}
+
+	cloud := &Server{cfg: config.Config{DeploymentMode: hostingCloud}}
+	if cloud.userCanAccessWorkspace(admin, other) {
+		t.Fatal("cloud admin reached another tenant's workspace")
+	}
+	if !cloud.userCanAccessWorkspace(admin, own) {
+		t.Fatal("cloud admin lost access to their own workspace")
+	}
+}

--- a/engine/internal/api/api_keys.go
+++ b/engine/internal/api/api_keys.go
@@ -26,12 +26,12 @@ func (s *Server) handleListAPIKeys(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, "invalid workspace id")
 			return
 		}
-		if !userCanAccessWorkspace(user, workspaceID) {
+		if !s.userCanAccessWorkspace(user, workspaceID) {
 			writeError(w, http.StatusForbidden, "workspace access required")
 			return
 		}
 		filter["workspace_id"] = workspaceID
-	} else if user.Role != "admin" {
+	} else if !s.globalDataScope(user) {
 		filter["workspace_id"] = bson.M{"$in": user.WorkspaceIDs}
 	}
 
@@ -77,7 +77,7 @@ func (s *Server) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "workspaceId is required")
 		return
 	}
-	if !userCanAccessWorkspace(user, workspaceID) {
+	if !s.userCanAccessWorkspace(user, workspaceID) {
 		writeError(w, http.StatusForbidden, "workspace access required")
 		return
 	}
@@ -137,7 +137,7 @@ func (s *Server) handleRevokeAPIKey(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "api key not found")
 		return
 	}
-	if !userCanAccessWorkspace(user, apiKey.WorkspaceID) {
+	if !s.userCanAccessWorkspace(user, apiKey.WorkspaceID) {
 		writeError(w, http.StatusForbidden, "workspace access required")
 		return
 	}
@@ -157,24 +157,23 @@ func (s *Server) handleRevokeAPIKey(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"apiKey": serializeAPIKey(apiKey)})
 }
 
-func (s *Server) authenticateIngest(w http.ResponseWriter, r *http.Request) (*Workspace, bool) {
+// authenticateIngest resolves the workspace a scan may be written to. It is
+// always the workspace the API key belongs to — never one named in the request
+// body — so a key issued for one workspace cannot deposit findings in another.
+func (s *Server) authenticateIngest(w http.ResponseWriter, r *http.Request) (Workspace, bool) {
 	apiKeyValue := apiKeyFromRequest(r)
-	if apiKeyValue != "" {
-		workspace, err := s.workspaceFromAPIKey(r.Context(), apiKeyValue)
-		if err != nil {
-			writeError(w, http.StatusUnauthorized, "invalid api key")
-			return nil, false
-		}
-
-		return &workspace, true
+	if apiKeyValue == "" {
+		writeError(w, http.StatusUnauthorized, "api key required")
+		return Workspace{}, false
 	}
 
-	if s.cfg.IngestToken != "" && r.Header.Get("X-Runtz-Token") != s.cfg.IngestToken {
-		writeError(w, http.StatusUnauthorized, "invalid ingest token")
-		return nil, false
+	workspace, err := s.workspaceFromAPIKey(r.Context(), apiKeyValue)
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "invalid api key")
+		return Workspace{}, false
 	}
 
-	return nil, true
+	return workspace, true
 }
 
 func (s *Server) workspaceFromAPIKey(ctx context.Context, rawKey string) (Workspace, error) {
@@ -209,8 +208,19 @@ func (s *Server) workspaceFromAPIKey(ctx context.Context, rawKey string) (Worksp
 	return workspace, nil
 }
 
-func userCanAccessWorkspace(user User, workspaceID bson.ObjectID) bool {
-	if user.Role == "admin" {
+// globalDataScope reports whether user may read data outside the workspaces
+// they belong to. Only a self-hosted admin may: there the whole installation
+// belongs to one customer, and administering it means seeing all of it. In
+// cloud every workspace belongs to a different customer and its scans carry
+// that customer's source-code findings, so no role widens data access beyond
+// membership — not even admin. Administration itself (users, workspaces,
+// licensing) stays role-gated in both modes; see adminOnly.
+func (s *Server) globalDataScope(user User) bool {
+	return user.Role == "admin" && s.cfg.DeploymentMode != hostingCloud
+}
+
+func (s *Server) userCanAccessWorkspace(user User, workspaceID bson.ObjectID) bool {
+	if s.globalDataScope(user) {
 		return true
 	}
 

--- a/engine/internal/api/auth_email.go
+++ b/engine/internal/api/auth_email.go
@@ -3,10 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
-	"crypto/hmac"
 	"crypto/rand"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -22,6 +19,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
+	"golang.org/x/crypto/bcrypt"
 )
 
 const (
@@ -30,7 +28,7 @@ const (
 	// maxEmailLoginAttempts wrong guesses kill the code (see the "attempts"
 	// filter in handleVerifyEmailLogin) and, on the same guess that reaches
 	// the limit, lock the email out of requesting or verifying any code for
-	// emailLoginLockoutTTL — see lockEmailLogin.
+	// emailLoginLockoutTTL — see lockLogin.
 	maxEmailLoginAttempts = 10
 	emailLoginLockoutTTL  = time.Hour
 )
@@ -43,18 +41,6 @@ type emailLoginCode struct {
 	CreatedAt time.Time     `bson:"created_at"`
 	ExpiresAt time.Time     `bson:"expires_at"`
 	UsedAt    *time.Time    `bson:"used_at,omitempty"`
-}
-
-// emailLoginLockout is deliberately its own collection, separate from
-// emailLoginCode: requesting a fresh code deletes prior unused codes and
-// their attempt counts (see handleRequestEmailLogin), so a per-code counter
-// alone cannot stop someone from just asking for a new code every ten
-// guesses. The lockout row survives that and blocks both endpoints for
-// emailLoginLockoutTTL, keyed by email rather than by any one code.
-type emailLoginLockout struct {
-	ID          bson.ObjectID `bson:"_id,omitempty"`
-	Email       string        `bson:"email"`
-	LockedUntil time.Time     `bson:"locked_until"`
 }
 
 func (s *Server) handleRequestEmailLogin(w http.ResponseWriter, r *http.Request) {
@@ -80,13 +66,13 @@ func (s *Server) handleRequestEmailLogin(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	lockedUntil, err := s.emailLoginLocked(r.Context(), email)
+	lockedUntil, err := s.loginLocked(r.Context(), emailLockoutKey(email))
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to prepare login email")
 		return
 	}
 	if !lockedUntil.IsZero() {
-		writeEmailLockoutError(w, lockedUntil)
+		writeLockoutError(w, lockedUntil, "codes")
 		return
 	}
 
@@ -115,10 +101,16 @@ func (s *Server) handleRequestEmailLogin(w http.ResponseWriter, r *http.Request)
 		"used_at": bson.M{"$exists": false},
 	})
 
+	codeHash, err := hashEmailLoginCode(email, code)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to prepare login email")
+		return
+	}
+
 	loginCode := emailLoginCode{
 		ID:        bson.NewObjectID(),
 		Email:     email,
-		CodeHash:  s.hashEmailLoginCode(email, code),
+		CodeHash:  codeHash,
 		CreatedAt: now,
 		ExpiresAt: now.Add(emailLoginCodeTTL),
 	}
@@ -157,13 +149,13 @@ func (s *Server) handleVerifyEmailLogin(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	lockedUntil, err := s.emailLoginLocked(r.Context(), email)
+	lockedUntil, err := s.loginLocked(r.Context(), emailLockoutKey(email))
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to verify login code")
 		return
 	}
 	if !lockedUntil.IsZero() {
-		writeEmailLockoutError(w, lockedUntil)
+		writeLockoutError(w, lockedUntil, "codes")
 		return
 	}
 
@@ -190,7 +182,7 @@ func (s *Server) handleVerifyEmailLogin(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if loginCode.CodeHash != s.hashEmailLoginCode(email, code) {
+	if !emailLoginCodeMatches(loginCode.CodeHash, email, code) {
 		// FindOneAndUpdate (not UpdateOne) so the post-increment count comes
 		// back atomically: two concurrent wrong guesses must not both read a
 		// stale count and both miss crossing the lockout threshold.
@@ -202,7 +194,7 @@ func (s *Server) handleVerifyEmailLogin(w http.ResponseWriter, r *http.Request) 
 			options.FindOneAndUpdate().SetReturnDocument(options.After),
 		).Decode(&afterAttempt)
 		if incErr == nil && afterAttempt.Attempts >= maxEmailLoginAttempts {
-			if lockErr := s.lockEmailLogin(r.Context(), email, now); lockErr != nil {
+			if lockErr := s.lockLogin(r.Context(), emailLockoutKey(email), now, emailLoginLockoutTTL); lockErr != nil {
 				slog.Warn("failed to lock email login after repeated wrong codes", "error", lockErr)
 			}
 		}
@@ -230,14 +222,12 @@ func (s *Server) handleVerifyEmailLogin(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusInternalServerError, "failed to sign in with email")
 		return
 	}
-	token, err := s.issueToken(user)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to issue token")
+	if err := s.startSession(w, r, user); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to start session")
 		return
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
-		"token":      token,
 		"user":       serializeUser(user),
 		"workspaces": serializeWorkspaces(workspaces),
 	})
@@ -333,64 +323,6 @@ func (s *Server) findOrCreateEmailUser(ctx context.Context, email string) (User,
 	return user, workspaces, nil
 }
 
-// emailLoginLocked returns the lockout's expiry if email is currently locked
-// out of the login-code endpoints, or the zero Time if it is not. It checks
-// the expiry itself rather than trusting that a matching document means an
-// active lockout, since the TTL index that removes expired lockouts runs on
-// a background sweep and is not instantaneous.
-func (s *Server) emailLoginLocked(ctx context.Context, email string) (time.Time, error) {
-	var lockout emailLoginLockout
-	err := s.emailLockouts.FindOne(ctx, bson.M{"email": email}).Decode(&lockout)
-	if errors.Is(err, mongo.ErrNoDocuments) {
-		return time.Time{}, nil
-	}
-	if err != nil {
-		return time.Time{}, err
-	}
-	if !time.Now().UTC().Before(lockout.LockedUntil) {
-		return time.Time{}, nil
-	}
-	return lockout.LockedUntil, nil
-}
-
-// lockEmailLogin locks email out of the login-code endpoints until
-// now+emailLoginLockoutTTL. Upserted (rather than inserted) so a repeat
-// offender within the same lockout window simply extends it instead of
-// erroring on the unique email index.
-func (s *Server) lockEmailLogin(ctx context.Context, email string, now time.Time) error {
-	_, err := s.emailLockouts.UpdateOne(
-		ctx,
-		bson.M{"email": email},
-		bson.M{
-			"$set": bson.M{"locked_until": now.Add(emailLoginLockoutTTL)},
-			"$setOnInsert": bson.M{
-				"_id":   bson.NewObjectID(),
-				"email": email,
-			},
-		},
-		options.UpdateOne().SetUpsert(true),
-	)
-	return err
-}
-
-// emailLockoutRetryMinutes formats the remaining lockout duration for the
-// error message. Rounded to the nearest minute, and never below one, so the
-// message never claims "try again in 0 minutes" while still locked.
-func emailLockoutRetryMinutes(lockedUntil, now time.Time) int {
-	minutes := int(lockedUntil.Sub(now).Round(time.Minute).Minutes())
-	if minutes < 1 {
-		return 1
-	}
-	return minutes
-}
-
-func writeEmailLockoutError(w http.ResponseWriter, lockedUntil time.Time) {
-	minutes := emailLockoutRetryMinutes(lockedUntil, time.Now().UTC())
-	writeError(w, http.StatusTooManyRequests, fmt.Sprintf(
-		"too many incorrect codes; try again in %d minute(s)", minutes,
-	))
-}
-
 func normalizeEmail(value string) (string, error) {
 	value = strings.ToLower(strings.TrimSpace(value))
 	address, err := mail.ParseAddress(value)
@@ -410,10 +342,23 @@ func generateEmailLoginCode() (string, error) {
 	return fmt.Sprintf("%06d", value.Int64()), nil
 }
 
-func (s *Server) hashEmailLoginCode(email, code string) string {
-	hasher := hmac.New(sha256.New, []byte(s.cfg.JWTSecret))
-	_, _ = hasher.Write([]byte(email + ":" + code))
-	return hex.EncodeToString(hasher.Sum(nil))
+// hashEmailLoginCode hashes a login code for storage. bcrypt — and not the
+// fast SHA-256 used for session and API key tokens — because this credential is
+// six digits: a leaked database of fast hashes would be reversed instantly by
+// walking all 10^6, while bcrypt makes that cost hours against a code that
+// lives ten minutes and dies after maxEmailLoginAttempts guesses. The email is
+// mixed in so a hash cannot be replayed against a different address.
+func hashEmailLoginCode(email, code string) (string, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(email+":"+code), bcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+
+	return string(hash), nil
+}
+
+func emailLoginCodeMatches(storedHash, email, code string) bool {
+	return bcrypt.CompareHashAndPassword([]byte(storedHash), []byte(email+":"+code)) == nil
 }
 
 func (s *Server) sendLoginCode(ctx context.Context, email, code string) error {

--- a/engine/internal/api/auth_email_test.go
+++ b/engine/internal/api/auth_email_test.go
@@ -3,8 +3,6 @@ package api
 import (
 	"testing"
 	"time"
-
-	"github.com/runtz-dev/runtz/engine/internal/config"
 )
 
 func TestNormalizeEmail(t *testing.T) {
@@ -84,24 +82,38 @@ func TestEmailLockoutRetryMinutes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := emailLockoutRetryMinutes(tt.lockedUntil, now); got != tt.want {
-				t.Fatalf("emailLockoutRetryMinutes() = %d, want %d", got, tt.want)
+			if got := lockoutRetryMinutes(tt.lockedUntil, now); got != tt.want {
+				t.Fatalf("lockoutRetryMinutes() = %d, want %d", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestHashEmailLoginCodeUsesEmailAndSecret(t *testing.T) {
+func TestEmailLoginCodeHashBindsEmailAndCode(t *testing.T) {
 	t.Parallel()
 
-	server := &Server{cfg: config.Config{JWTSecret: "first-secret"}}
-	hash := server.hashEmailLoginCode("user@example.com", "123456")
-	if hash == server.hashEmailLoginCode("other@example.com", "123456") {
-		t.Fatal("expected email to affect hash")
+	hash, err := hashEmailLoginCode("user@example.com", "123456")
+	if err != nil {
+		t.Fatalf("hashEmailLoginCode() error = %v", err)
 	}
 
-	otherServer := &Server{cfg: config.Config{JWTSecret: "second-secret"}}
-	if hash == otherServer.hashEmailLoginCode("user@example.com", "123456") {
-		t.Fatal("expected JWT secret to affect hash")
+	if !emailLoginCodeMatches(hash, "user@example.com", "123456") {
+		t.Fatal("the issued code did not verify against its own hash")
+	}
+	if emailLoginCodeMatches(hash, "other@example.com", "123456") {
+		t.Fatal("a code verified against a different email")
+	}
+	if emailLoginCodeMatches(hash, "user@example.com", "654321") {
+		t.Fatal("a wrong code verified")
+	}
+
+	// bcrypt salts, so the same input must not produce a reusable constant —
+	// two codes issued to the same address cannot be compared by their hashes.
+	second, err := hashEmailLoginCode("user@example.com", "123456")
+	if err != nil {
+		t.Fatalf("hashEmailLoginCode() error = %v", err)
+	}
+	if hash == second {
+		t.Fatal("expected salted hashes to differ")
 	}
 }

--- a/engine/internal/api/auth_github.go
+++ b/engine/internal/api/auth_github.go
@@ -88,14 +88,12 @@ func (s *Server) handleGitHubLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := s.issueToken(user)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to issue token")
+	if err := s.startSession(w, r, user); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to start session")
 		return
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
-		"token":      token,
 		"user":       serializeUser(user),
 		"workspaces": serializeWorkspaces(workspaces),
 	})

--- a/engine/internal/api/auth_google.go
+++ b/engine/internal/api/auth_google.go
@@ -70,14 +70,12 @@ func (s *Server) handleGoogleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := s.issueToken(user)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to issue token")
+	if err := s.startSession(w, r, user); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to start session")
 		return
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
-		"token":      token,
 		"user":       serializeUser(user),
 		"workspaces": serializeWorkspaces(workspaces),
 	})

--- a/engine/internal/api/billing.go
+++ b/engine/internal/api/billing.go
@@ -105,7 +105,7 @@ func (s *Server) handleCreateCheckoutSession(w http.ResponseWriter, r *http.Requ
 	}
 
 	if s.cfg.DeploymentMode == hostingSelfHosted {
-		user, ok := s.optionalUserFromBearer(r)
+		user, ok := s.optionalUserFromSession(r)
 		if !ok || user.Role != "admin" {
 			writeError(w, http.StatusForbidden, "admin role required")
 			return
@@ -151,7 +151,7 @@ func (s *Server) handleCreateCheckoutSession(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	user, hasUser := s.optionalUserFromBearer(r)
+	user, hasUser := s.optionalUserFromSession(r)
 	email := strings.ToLower(strings.TrimSpace(request.Email))
 	if email == "" && hasUser {
 		email = strings.ToLower(strings.TrimSpace(user.Email))
@@ -712,22 +712,14 @@ func parseStripeSignatureHeader(header string) map[string]string {
 	return values
 }
 
-func (s *Server) optionalUserFromBearer(r *http.Request) (User, bool) {
-	header := strings.TrimSpace(r.Header.Get("Authorization"))
-	if !strings.HasPrefix(header, "Bearer ") {
-		return User{}, false
-	}
-	userID, err := s.userIDFromToken(strings.TrimPrefix(header, "Bearer "))
-	if err != nil {
-		return User{}, false
-	}
-	objectID, err := bson.ObjectIDFromHex(userID)
-	if err != nil {
+func (s *Server) optionalUserFromSession(r *http.Request) (User, bool) {
+	rawToken := sessionTokenFromRequest(r)
+	if rawToken == "" {
 		return User{}, false
 	}
 
-	var user User
-	if err := s.users.FindOne(r.Context(), bson.M{"_id": objectID}).Decode(&user); err != nil {
+	user, err := s.userFromSession(r.Context(), rawToken)
+	if err != nil {
 		return User{}, false
 	}
 	return user, true

--- a/engine/internal/api/login_lockout.go
+++ b/engine/internal/api/login_lockout.go
@@ -1,0 +1,137 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+const (
+	// maxPasswordLoginAttempts wrong passwords lock the username out for
+	// passwordLoginLockoutTTL. Unlike the email code flow — where each code
+	// carries its own attempt counter — password login has no per-attempt
+	// document, so the count lives on the lockout row itself.
+	maxPasswordLoginAttempts = 10
+	passwordLoginLockoutTTL  = time.Hour
+)
+
+// loginLockout throttles a single login identity. It is deliberately its own
+// collection rather than a counter on the credential being guessed: the email
+// flow deletes prior unused codes whenever a fresh one is requested, so a
+// per-code counter alone cannot stop someone from asking for a new code every
+// ten guesses. The lockout row survives that.
+//
+// Key namespaces the identity ("email:someone@example.com", "user:admin") so
+// the two login paths cannot collide or unlock each other.
+type loginLockout struct {
+	ID          bson.ObjectID `bson:"_id,omitempty"`
+	Key         string        `bson:"key"`
+	Attempts    int           `bson:"attempts"`
+	LockedUntil time.Time     `bson:"locked_until"`
+}
+
+func emailLockoutKey(email string) string { return "email:" + email }
+
+func passwordLockoutKey(username string) string { return "user:" + username }
+
+// loginLocked returns the lockout's expiry if key is currently locked out, or
+// the zero Time if it is not. It checks the expiry itself rather than trusting
+// that a matching document means an active lockout, since the TTL index that
+// removes expired lockouts runs on a background sweep and is not instantaneous.
+func (s *Server) loginLocked(ctx context.Context, key string) (time.Time, error) {
+	var lockout loginLockout
+	err := s.loginLockouts.FindOne(ctx, bson.M{"key": key}).Decode(&lockout)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return time.Time{}, nil
+	}
+	if err != nil {
+		return time.Time{}, err
+	}
+	if !time.Now().UTC().Before(lockout.LockedUntil) {
+		return time.Time{}, nil
+	}
+	return lockout.LockedUntil, nil
+}
+
+// lockLogin locks key out until now+ttl. Upserted (rather than inserted) so a
+// repeat offender within the same window simply extends it instead of erroring
+// on the unique key index.
+func (s *Server) lockLogin(ctx context.Context, key string, now time.Time, ttl time.Duration) error {
+	_, err := s.loginLockouts.UpdateOne(
+		ctx,
+		bson.M{"key": key},
+		bson.M{
+			"$set": bson.M{"locked_until": now.Add(ttl)},
+			"$setOnInsert": bson.M{
+				"_id": bson.NewObjectID(),
+				"key": key,
+			},
+		},
+		options.UpdateOne().SetUpsert(true),
+	)
+	return err
+}
+
+// registerFailedLogin counts one failure against key and locks it once the
+// count reaches max. FindOneAndUpdate (not UpdateOne) so the post-increment
+// count comes back atomically: two concurrent wrong guesses must not both read
+// a stale count and both miss crossing the threshold.
+//
+// locked_until is seeded in the past on insert so the TTL index still reaps
+// rows for identities that never reach the threshold, and so loginLocked reads
+// them as unlocked in the meantime.
+func (s *Server) registerFailedLogin(ctx context.Context, key string, now time.Time, max int, ttl time.Duration) error {
+	var lockout loginLockout
+	err := s.loginLockouts.FindOneAndUpdate(
+		ctx,
+		bson.M{"key": key},
+		bson.M{
+			"$inc": bson.M{"attempts": 1},
+			"$setOnInsert": bson.M{
+				"_id":          bson.NewObjectID(),
+				"key":          key,
+				"locked_until": now.Add(-time.Second),
+			},
+		},
+		options.FindOneAndUpdate().SetUpsert(true).SetReturnDocument(options.After),
+	).Decode(&lockout)
+	if err != nil {
+		return err
+	}
+	if lockout.Attempts < max {
+		return nil
+	}
+
+	return s.lockLogin(ctx, key, now, ttl)
+}
+
+// clearLoginFailures drops the failure count after a successful login so a user
+// who mistypes a few times and then gets in does not carry the count forward.
+func (s *Server) clearLoginFailures(ctx context.Context, key string) error {
+	_, err := s.loginLockouts.DeleteOne(ctx, bson.M{"key": key})
+	return err
+}
+
+// lockoutRetryMinutes formats the remaining lockout duration for the error
+// message. Rounded to the nearest minute, and never below one, so the message
+// never claims "try again in 0 minutes" while still locked.
+func lockoutRetryMinutes(lockedUntil, now time.Time) int {
+	minutes := int(lockedUntil.Sub(now).Round(time.Minute).Minutes())
+	if minutes < 1 {
+		return 1
+	}
+	return minutes
+}
+
+func writeLockoutError(w http.ResponseWriter, lockedUntil time.Time, what string) {
+	minutes := lockoutRetryMinutes(lockedUntil, time.Now().UTC())
+	writeError(w, http.StatusTooManyRequests, fmt.Sprintf(
+		"too many incorrect %s; try again in %d minute(s)", what, minutes,
+	))
+}

--- a/engine/internal/api/login_lockout_test.go
+++ b/engine/internal/api/login_lockout_test.go
@@ -1,0 +1,18 @@
+package api
+
+import "testing"
+
+func TestLockoutKeysAreNamespaced(t *testing.T) {
+	t.Parallel()
+
+	// A username equal to an email address must not share a lockout row with
+	// the email login flow: locking one path would otherwise lock the other,
+	// and a successful login on one would clear the other's failure count.
+	const same = "someone@example.com"
+	if emailLockoutKey(same) == passwordLockoutKey(same) {
+		t.Fatal("email and password lockout keys collided")
+	}
+	if emailLockoutKey("a") == emailLockoutKey("b") {
+		t.Fatal("distinct emails shared a lockout key")
+	}
+}

--- a/engine/internal/api/server.go
+++ b/engine/internal/api/server.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -14,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/runtz-dev/runtz/engine/internal/config"
 	"github.com/runtz-dev/runtz/engine/internal/version"
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -32,7 +30,8 @@ type Server struct {
 	apiKeys              *mongo.Collection
 	scans                *mongo.Collection
 	emailCodes           *mongo.Collection
-	emailLockouts        *mongo.Collection
+	loginLockouts        *mongo.Collection
+	sessions             *mongo.Collection
 	billingSubscriptions *mongo.Collection
 	instanceState        *mongo.Collection
 
@@ -65,7 +64,8 @@ func New(ctx context.Context, cfg config.Config) (*Server, error) {
 		apiKeys:              db.Collection("api_keys"),
 		scans:                db.Collection("scans"),
 		emailCodes:           db.Collection("email_login_codes"),
-		emailLockouts:        db.Collection("email_login_lockouts"),
+		loginLockouts:        db.Collection("login_lockouts"),
+		sessions:             db.Collection("sessions"),
 		billingSubscriptions: db.Collection("billing_subscriptions"),
 		instanceState:        db.Collection("instance_state"),
 	}
@@ -94,6 +94,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /api/v1/auth/github", s.handleGitHubLogin)
 	mux.HandleFunc("POST /api/v1/auth/email/request", s.handleRequestEmailLogin)
 	mux.HandleFunc("POST /api/v1/auth/email/verify", s.handleVerifyEmailLogin)
+	mux.HandleFunc("POST /api/v1/auth/logout", s.handleLogout)
 	mux.Handle("GET /api/v1/me", s.auth(http.HandlerFunc(s.handleMe)))
 	mux.Handle("PATCH /api/v1/me/onboarding", s.auth(http.HandlerFunc(s.handleCompleteOnboarding)))
 	mux.Handle("PATCH /api/v1/me/password", s.auth(http.HandlerFunc(s.handleChangePassword)))
@@ -207,9 +208,26 @@ func (s *Server) ensureIndexes(ctx context.Context) error {
 		return fmt.Errorf("create email login code indexes: %w", err)
 	}
 
-	_, err = s.emailLockouts.Indexes().CreateMany(ctx, []mongo.IndexModel{
+	_, err = s.sessions.Indexes().CreateMany(ctx, []mongo.IndexModel{
 		{
-			Keys:    bson.D{{Key: "email", Value: 1}},
+			Keys:    bson.D{{Key: "token_hash", Value: 1}},
+			Options: options.Index().SetUnique(true),
+		},
+		{Keys: bson.D{{Key: "user_id", Value: 1}, {Key: "created_at", Value: -1}}},
+		{
+			// Mongo reaps expired sessions on its own, so nothing has to sweep
+			// the collection and a signed-out week-old row cannot linger.
+			Keys:    bson.D{{Key: "expires_at", Value: 1}},
+			Options: options.Index().SetExpireAfterSeconds(0),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("create session indexes: %w", err)
+	}
+
+	_, err = s.loginLockouts.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys:    bson.D{{Key: "key", Value: 1}},
 			Options: options.Index().SetUnique(true),
 		},
 		{
@@ -218,7 +236,7 @@ func (s *Server) ensureIndexes(ctx context.Context) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("create email login lockout indexes: %w", err)
+		return fmt.Errorf("create login lockout indexes: %w", err)
 	}
 
 	_, err = s.billingSubscriptions.Indexes().CreateMany(ctx, []mongo.IndexModel{
@@ -265,7 +283,7 @@ func (s *Server) withCORS(next http.Handler) http.Handler {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Vary", "Origin")
 			w.Header().Set("Access-Control-Allow-Credentials", "true")
-			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Runtz-Token, X-Runtz-API-Key")
+			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Runtz-API-Key")
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PATCH, OPTIONS")
 		}
 
@@ -294,27 +312,15 @@ func (s *Server) originAllowed(origin string) bool {
 
 func (s *Server) auth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		header := strings.TrimSpace(r.Header.Get("Authorization"))
-		if !strings.HasPrefix(header, "Bearer ") {
-			writeError(w, http.StatusUnauthorized, "missing bearer token")
+		rawToken := sessionTokenFromRequest(r)
+		if rawToken == "" {
+			writeError(w, http.StatusUnauthorized, "missing session")
 			return
 		}
 
-		userID, err := s.userIDFromToken(strings.TrimPrefix(header, "Bearer "))
+		user, err := s.userFromSession(r.Context(), rawToken)
 		if err != nil {
-			writeError(w, http.StatusUnauthorized, "invalid bearer token")
-			return
-		}
-
-		objectID, err := bson.ObjectIDFromHex(userID)
-		if err != nil {
-			writeError(w, http.StatusUnauthorized, "invalid token subject")
-			return
-		}
-
-		var user User
-		if err := s.users.FindOne(r.Context(), bson.M{"_id": objectID}).Decode(&user); err != nil {
-			writeError(w, http.StatusUnauthorized, "user not found")
+			writeError(w, http.StatusUnauthorized, "invalid session")
 			return
 		}
 
@@ -439,14 +445,12 @@ func (s *Server) handleSetup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := s.issueToken(user)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to issue token")
+	if err := s.startSession(w, r, user); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to start session")
 		return
 	}
 
 	writeJSON(w, http.StatusCreated, map[string]any{
-		"token":     token,
 		"user":      serializeUser(user),
 		"workspace": serializeWorkspace(workspace),
 	})
@@ -466,22 +470,44 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	username := strings.TrimSpace(request.Username)
+	lockoutKey := passwordLockoutKey(username)
+
+	lockedUntil, err := s.loginLocked(r.Context(), lockoutKey)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to verify credentials")
+		return
+	}
+	if !lockedUntil.IsZero() {
+		writeLockoutError(w, lockedUntil, "passwords")
+		return
+	}
+
+	// The lookup miss and the password mismatch share one branch and one
+	// message so the response does not reveal whether the username exists.
 	var user User
-	err := s.users.FindOne(r.Context(), bson.M{"username": strings.TrimSpace(request.Username)}).Decode(&user)
+	err = s.users.FindOne(r.Context(), bson.M{"username": username}).Decode(&user)
 	if err != nil || bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(request.Password)) != nil {
+		if lockErr := s.registerFailedLogin(
+			r.Context(), lockoutKey, time.Now().UTC(), maxPasswordLoginAttempts, passwordLoginLockoutTTL,
+		); lockErr != nil {
+			slog.Warn("failed to record login failure", "error", lockErr)
+		}
 		writeError(w, http.StatusUnauthorized, "invalid username or password")
 		return
 	}
 
-	token, err := s.issueToken(user)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to issue token")
+	if err := s.clearLoginFailures(r.Context(), lockoutKey); err != nil {
+		slog.Warn("failed to clear login failures", "error", err)
+	}
+
+	if err := s.startSession(w, r, user); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to start session")
 		return
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
-		"token": token,
-		"user":  serializeUser(user),
+		"user": serializeUser(user),
 	})
 }
 
@@ -764,12 +790,15 @@ func (s *Server) handleCreateInvite(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleIngestSCA(w http.ResponseWriter, r *http.Request) {
-	authWorkspace, ok := s.authenticateIngest(w, r)
+	workspace, ok := s.authenticateIngest(w, r)
 	if !ok {
 		return
 	}
 
 	var request struct {
+		// workspaceId/workspace are accepted and ignored: the workspace comes
+		// from the API key. They stay in the struct because decodeJSON rejects
+		// unknown fields, and older CLI versions still send them.
 		WorkspaceID     string          `json:"workspaceId"`
 		Workspace       string          `json:"workspace"`
 		ProjectName     string          `json:"projectName"`
@@ -786,18 +815,6 @@ func (s *Server) handleIngestSCA(w http.ResponseWriter, r *http.Request) {
 	if strings.TrimSpace(request.ProjectName) == "" {
 		writeError(w, http.StatusBadRequest, "projectName is required")
 		return
-	}
-
-	var workspace Workspace
-	if authWorkspace != nil {
-		workspace = *authWorkspace
-	} else {
-		resolved, err := s.resolveWorkspace(r.Context(), request.WorkspaceID, request.Workspace)
-		if err != nil {
-			writeError(w, http.StatusBadRequest, err.Error())
-			return
-		}
-		workspace = resolved
 	}
 
 	now := time.Now().UTC()
@@ -838,12 +855,15 @@ func (s *Server) handleIngestK8s(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleIngestFindingsScan(w http.ResponseWriter, r *http.Request, scanType string) {
-	authWorkspace, ok := s.authenticateIngest(w, r)
+	workspace, ok := s.authenticateIngest(w, r)
 	if !ok {
 		return
 	}
 
 	var request struct {
+		// workspaceId/workspace are accepted and ignored: the workspace comes
+		// from the API key. They stay in the struct because decodeJSON rejects
+		// unknown fields, and older CLI versions still send them.
 		WorkspaceID      string    `json:"workspaceId"`
 		Workspace        string    `json:"workspace"`
 		ProjectName      string    `json:"projectName"`
@@ -866,18 +886,6 @@ func (s *Server) handleIngestFindingsScan(w http.ResponseWriter, r *http.Request
 	projectName := strings.TrimSpace(request.ProjectName)
 	if projectName == "" {
 		projectName = targetName
-	}
-
-	var workspace Workspace
-	if authWorkspace != nil {
-		workspace = *authWorkspace
-	} else {
-		resolved, err := s.resolveWorkspace(r.Context(), request.WorkspaceID, request.Workspace)
-		if err != nil {
-			writeError(w, http.StatusBadRequest, err.Error())
-			return
-		}
-		workspace = resolved
 	}
 
 	now := time.Now().UTC()
@@ -923,12 +931,15 @@ func (s *Server) handleIngestContainer(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleIngestPackageScan(w http.ResponseWriter, r *http.Request, scanType string) {
-	authWorkspace, ok := s.authenticateIngest(w, r)
+	workspace, ok := s.authenticateIngest(w, r)
 	if !ok {
 		return
 	}
 
 	var request struct {
+		// workspaceId/workspace are accepted and ignored: the workspace comes
+		// from the API key. They stay in the struct because decodeJSON rejects
+		// unknown fields, and older CLI versions still send them.
 		WorkspaceID     string          `json:"workspaceId"`
 		Workspace       string          `json:"workspace"`
 		TargetName      string          `json:"targetName"`
@@ -960,18 +971,6 @@ func (s *Server) handleIngestPackageScan(w http.ResponseWriter, r *http.Request,
 	if targetName == "" {
 		writeError(w, http.StatusBadRequest, "targetName is required")
 		return
-	}
-
-	var workspace Workspace
-	if authWorkspace != nil {
-		workspace = *authWorkspace
-	} else {
-		resolved, err := s.resolveWorkspace(r.Context(), request.WorkspaceID, request.Workspace)
-		if err != nil {
-			writeError(w, http.StatusBadRequest, err.Error())
-			return
-		}
-		workspace = resolved
 	}
 
 	now := time.Now().UTC()
@@ -1041,12 +1040,12 @@ func (s *Server) handleListScansByType(w http.ResponseWriter, r *http.Request, s
 			writeError(w, http.StatusBadRequest, "invalid workspace id")
 			return
 		}
-		if !userCanAccessWorkspace(user, workspaceID) {
+		if !s.userCanAccessWorkspace(user, workspaceID) {
 			writeError(w, http.StatusForbidden, "workspace access required")
 			return
 		}
 		filter["workspace_id"] = workspaceID
-	} else if user.Role != "admin" {
+	} else if !s.globalDataScope(user) {
 		filter["workspace_id"] = bson.M{"$in": user.WorkspaceIDs}
 	}
 
@@ -1103,7 +1102,7 @@ func (s *Server) handleGetScanByType(w http.ResponseWriter, r *http.Request, sca
 		writeError(w, http.StatusNotFound, "scan not found")
 		return
 	}
-	if !userCanAccessWorkspace(user, scan.WorkspaceID) {
+	if !s.userCanAccessWorkspace(user, scan.WorkspaceID) {
 		writeError(w, http.StatusForbidden, "workspace access required")
 		return
 	}
@@ -1111,52 +1110,9 @@ func (s *Server) handleGetScanByType(w http.ResponseWriter, r *http.Request, sca
 	writeJSON(w, http.StatusOK, map[string]any{"scan": scan})
 }
 
-// sessionTokenTTL is how long a browser session stays signed in. The token is
-// kept in localStorage, so a short TTL means signing in again every day even
-// though the tab was never closed; a week is the balance we settled on.
-const sessionTokenTTL = 7 * 24 * time.Hour
-
-func (s *Server) issueToken(user User) (string, error) {
-	claims := jwt.MapClaims{
-		"sub":      user.ID.Hex(),
-		"username": user.Username,
-		"role":     user.Role,
-		"exp":      time.Now().UTC().Add(sessionTokenTTL).Unix(),
-		"iat":      time.Now().UTC().Unix(),
-	}
-
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	return token.SignedString([]byte(s.cfg.JWTSecret))
-}
-
-func (s *Server) userIDFromToken(rawToken string) (string, error) {
-	token, err := jwt.Parse(rawToken, func(token *jwt.Token) (any, error) {
-		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, errors.New("unexpected signing method")
-		}
-
-		return []byte(s.cfg.JWTSecret), nil
-	})
-	if err != nil || !token.Valid {
-		return "", errors.New("invalid token")
-	}
-
-	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok {
-		return "", errors.New("invalid claims")
-	}
-
-	subject, err := claims.GetSubject()
-	if err != nil || subject == "" {
-		return "", errors.New("missing subject")
-	}
-
-	return subject, nil
-}
-
 func (s *Server) getVisibleWorkspaces(ctx context.Context, user User) ([]Workspace, error) {
 	filter := bson.M{}
-	if user.Role != "admin" {
+	if !s.globalDataScope(user) {
 		filter["_id"] = bson.M{"$in": user.WorkspaceIDs}
 	}
 
@@ -1212,55 +1168,6 @@ func (s *Server) getAllWorkspaces(ctx context.Context) ([]Workspace, error) {
 	}
 
 	return workspaces, nil
-}
-
-func (s *Server) resolveWorkspace(ctx context.Context, rawID, nameOrSlug string) (Workspace, error) {
-	if rawID != "" {
-		workspaceID, err := bson.ObjectIDFromHex(rawID)
-		if err != nil {
-			return Workspace{}, errors.New("invalid workspace id")
-		}
-
-		var workspace Workspace
-		if err := s.workspaces.FindOne(ctx, bson.M{"_id": workspaceID}).Decode(&workspace); err != nil {
-			return Workspace{}, errors.New("workspace not found")
-		}
-
-		return workspace, nil
-	}
-
-	value := strings.TrimSpace(nameOrSlug)
-	if value != "" {
-		var workspace Workspace
-		filter := bson.M{"$or": []bson.M{{"slug": slugify(value)}, {"name": value}}}
-		if err := s.workspaces.FindOne(ctx, filter).Decode(&workspace); err == nil {
-			return workspace, nil
-		}
-
-		now := time.Now().UTC()
-		workspace = Workspace{
-			ID:        bson.NewObjectID(),
-			Name:      value,
-			Slug:      slugify(value),
-			CreatedAt: now,
-			UpdatedAt: now,
-		}
-		if _, err := s.workspaces.InsertOne(ctx, workspace); err != nil {
-			return Workspace{}, errors.New("workspace not found and could not be created")
-		}
-
-		return workspace, nil
-	}
-
-	workspaces, err := s.getAllWorkspaces(ctx)
-	if err != nil {
-		return Workspace{}, errors.New("failed to resolve workspace")
-	}
-	if len(workspaces) != 1 {
-		return Workspace{}, errors.New("workspace must be provided when multiple workspaces exist")
-	}
-
-	return workspaces[0], nil
 }
 
 func buildSummary(dependencies []Dependency, vulnerabilities []Vulnerability) ScanSummary {

--- a/engine/internal/api/sessions.go
+++ b/engine/internal/api/sessions.go
@@ -1,0 +1,199 @@
+package api
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+const (
+	// sessionCookieName carries the browser session. It is opaque: the value
+	// is a random string whose SHA-256 is the only thing stored server-side,
+	// so nothing about the user can be read out of it and nothing about it can
+	// be forged without guessing 256 bits.
+	sessionCookieName = "runtz_session"
+
+	// sessionTTL is how long a browser session stays signed in.
+	sessionTTL = 7 * 24 * time.Hour
+
+	// sessionTouchInterval throttles last_used_at writes: bumping it on every
+	// single request would turn a read-only page load into a write.
+	sessionTouchInterval = 5 * time.Minute
+)
+
+// Session is a browser login. The raw token is never stored — only its hash —
+// so a database leak yields no usable session, the same reasoning that applies
+// to APIKey.KeyHash. A fast hash is the right choice here (and not bcrypt as
+// for passwords): the token is 256 bits of entropy, so there is no dictionary
+// to defend against, only a search space nobody can walk.
+type Session struct {
+	ID         bson.ObjectID `bson:"_id,omitempty"`
+	UserID     bson.ObjectID `bson:"user_id"`
+	TokenHash  string        `bson:"token_hash"`
+	UserAgent  string        `bson:"user_agent,omitempty"`
+	CreatedAt  time.Time     `bson:"created_at"`
+	LastUsedAt time.Time     `bson:"last_used_at"`
+	ExpiresAt  time.Time     `bson:"expires_at"`
+}
+
+func hashSessionToken(rawToken string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(rawToken)))
+	return hex.EncodeToString(sum[:])
+}
+
+// issueSession creates a session for user and returns the raw token to hand to
+// the browser. The raw value exists only in this return and in the cookie; it
+// is never written down.
+func (s *Server) issueSession(ctx context.Context, user User, r *http.Request) (string, error) {
+	rawToken, err := randomHex(32)
+	if err != nil {
+		return "", err
+	}
+
+	now := time.Now().UTC()
+	session := Session{
+		ID:         bson.NewObjectID(),
+		UserID:     user.ID,
+		TokenHash:  hashSessionToken(rawToken),
+		UserAgent:  truncate(r.UserAgent(), 200),
+		CreatedAt:  now,
+		LastUsedAt: now,
+		ExpiresAt:  now.Add(sessionTTL),
+	}
+	if _, err := s.sessions.InsertOne(ctx, session); err != nil {
+		return "", err
+	}
+
+	return rawToken, nil
+}
+
+// userFromSession resolves the user behind a raw session token. The expiry is
+// filtered here rather than left to the TTL index, which sweeps in the
+// background and is not instantaneous.
+func (s *Server) userFromSession(ctx context.Context, rawToken string) (User, error) {
+	rawToken = strings.TrimSpace(rawToken)
+	if rawToken == "" {
+		return User{}, errors.New("missing session token")
+	}
+
+	var session Session
+	err := s.sessions.FindOne(ctx, bson.M{
+		"token_hash": hashSessionToken(rawToken),
+		"expires_at": bson.M{"$gt": time.Now().UTC()},
+	}).Decode(&session)
+	if err != nil {
+		return User{}, errors.New("invalid session")
+	}
+
+	var user User
+	if err := s.users.FindOne(ctx, bson.M{"_id": session.UserID}).Decode(&user); err != nil {
+		return User{}, errors.New("user not found")
+	}
+
+	s.touchSession(ctx, session)
+	return user, nil
+}
+
+func (s *Server) touchSession(ctx context.Context, session Session) {
+	now := time.Now().UTC()
+	if now.Sub(session.LastUsedAt) < sessionTouchInterval {
+		return
+	}
+
+	_, _ = s.sessions.UpdateOne(
+		ctx,
+		bson.M{"_id": session.ID},
+		bson.M{"$set": bson.M{"last_used_at": now}},
+	)
+}
+
+// revokeSession deletes a single session. Deleting rather than flagging keeps
+// the collection self-cleaning, and there is no audit requirement that would
+// justify keeping spent rows around.
+func (s *Server) revokeSession(ctx context.Context, rawToken string) error {
+	_, err := s.sessions.DeleteOne(ctx, bson.M{"token_hash": hashSessionToken(rawToken)})
+	return err
+}
+
+func sessionTokenFromRequest(r *http.Request) string {
+	cookie, err := r.Cookie(sessionCookieName)
+	if err != nil {
+		return ""
+	}
+	return cookie.Value
+}
+
+// sessionCookieSecure marks the cookie Secure whenever the platform is served
+// over HTTPS. It cannot be unconditional: a Secure cookie is dropped by the
+// browser on plain http, which is exactly how the self-hosted quickstart runs
+// on localhost.
+func (s *Server) sessionCookieSecure() bool {
+	return strings.HasPrefix(strings.ToLower(s.cfg.PublicURL), "https://")
+}
+
+// setSessionCookie writes the session cookie. SameSite=Lax is what stands in
+// for CSRF tokens here: it withholds the cookie from cross-site POST/PATCH,
+// and no GET in this API mutates state. It works because the browser reaches
+// the engine same-origin through the frontend proxy, so the cookie is
+// first-party and needs neither SameSite=None nor HTTPS in development.
+func (s *Server) setSessionCookie(w http.ResponseWriter, rawToken string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    rawToken,
+		Path:     "/",
+		MaxAge:   int(sessionTTL.Seconds()),
+		HttpOnly: true,
+		Secure:   s.sessionCookieSecure(),
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func (s *Server) clearSessionCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   s.sessionCookieSecure(),
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// startSession issues the session and sets the cookie. Login handlers call
+// this instead of returning a token in the body — the browser never sees the
+// credential in JavaScript-readable form.
+func (s *Server) startSession(w http.ResponseWriter, r *http.Request, user User) error {
+	rawToken, err := s.issueSession(r.Context(), user, r)
+	if err != nil {
+		return err
+	}
+	s.setSessionCookie(w, rawToken)
+	return nil
+}
+
+func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
+	if rawToken := sessionTokenFromRequest(r); rawToken != "" {
+		if err := s.revokeSession(r.Context(), rawToken); err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to end session")
+			return
+		}
+	}
+
+	s.clearSessionCookie(w)
+	writeJSON(w, http.StatusOK, map[string]string{"status": "signed_out"})
+}
+
+func truncate(value string, max int) string {
+	value = strings.TrimSpace(value)
+	if len(value) <= max {
+		return value
+	}
+	return value[:max]
+}

--- a/engine/internal/api/usage.go
+++ b/engine/internal/api/usage.go
@@ -35,12 +35,12 @@ func (s *Server) handleUsage(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, "invalid workspace id")
 			return
 		}
-		if !userCanAccessWorkspace(user, workspaceID) {
+		if !s.userCanAccessWorkspace(user, workspaceID) {
 			writeError(w, http.StatusForbidden, "workspace access required")
 			return
 		}
 		filter["workspace_id"] = workspaceID
-	} else if user.Role != "admin" {
+	} else if !s.globalDataScope(user) {
 		filter["workspace_id"] = bson.M{"$in": user.WorkspaceIDs}
 	}
 

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"strings"
 )
@@ -25,8 +24,6 @@ type Config struct {
 	Port                            string
 	MongoURI                        string
 	MongoDatabase                   string
-	JWTSecret                       string
-	IngestToken                     string
 	DeploymentMode                  string
 	PublicURL                       string
 	GoogleClientID                  string
@@ -50,8 +47,6 @@ func Load() Config {
 		Port:                            getEnv("PORT", "8080"),
 		MongoURI:                        getEnv("MONGODB_URI", "mongodb://localhost:27017"),
 		MongoDatabase:                   getEnv("MONGODB_DATABASE", "runtz"),
-		JWTSecret:                       getEnv("JWT_SECRET", ""),
-		IngestToken:                     getEnv("RUNTZ_INGEST_TOKEN", ""),
 		DeploymentMode:                  normalizeDeploymentMode(getEnv("RUNTZ_DEPLOYMENT_MODE", "self-hosted")),
 		PublicURL:                       strings.TrimRight(getEnv("RUNTZ_PUBLIC_URL", "http://localhost:3000"), "/"),
 		GoogleClientID:                  getEnv("GOOGLE_CLIENT_ID", ""),
@@ -73,36 +68,11 @@ func Load() Config {
 	}
 }
 
-// weakSecrets are placeholder values that previously shipped as defaults or in
-// example files. They must never authenticate a real deployment.
-var weakSecrets = map[string]bool{
-	"change-me-in-production":     true,
-	"change-me-before-sharing":    true,
-	"change-me-before-production": true,
-	"dev-ingest-token":            true,
-}
-
-const (
-	minJWTSecretLength   = 32
-	minIngestTokenLength = 16
-)
-
-// Validate rejects configurations that would run the engine with missing or
-// well-known placeholder credentials. It is meant to be called once at startup.
+// Validate is kept as the startup hook for configuration checks. It has no
+// secrets left to police: sessions, API keys and login codes are all issued
+// and stored by the engine itself, so there is nothing an operator can set
+// weakly or forget to set.
 func (c Config) Validate() error {
-	if c.JWTSecret == "" || weakSecrets[c.JWTSecret] {
-		return fmt.Errorf("JWT_SECRET must be set to a strong random value; generate one with: openssl rand -base64 32")
-	}
-	if len(c.JWTSecret) < minJWTSecretLength {
-		return fmt.Errorf("JWT_SECRET must be at least %d characters; generate one with: openssl rand -base64 32", minJWTSecretLength)
-	}
-	if c.IngestToken == "" || weakSecrets[c.IngestToken] {
-		return fmt.Errorf("RUNTZ_INGEST_TOKEN must be set to a strong random value; generate one with: openssl rand -base64 24")
-	}
-	if len(c.IngestToken) < minIngestTokenLength {
-		return fmt.Errorf("RUNTZ_INGEST_TOKEN must be at least %d characters; generate one with: openssl rand -base64 24", minIngestTokenLength)
-	}
-
 	return nil
 }
 

--- a/engine/internal/config/config_test.go
+++ b/engine/internal/config/config_test.go
@@ -1,49 +1,16 @@
 package config
 
-import (
-	"strings"
-	"testing"
-)
+import "testing"
 
-func TestValidateAcceptsStrongSecrets(t *testing.T) {
-	cfg := Config{
-		JWTSecret:   strings.Repeat("a", minJWTSecretLength),
-		IngestToken: strings.Repeat("b", minIngestTokenLength),
-	}
+// The engine used to refuse to start on a missing or placeholder JWT_SECRET /
+// RUNTZ_INGEST_TOKEN, and this file tested every way of getting that wrong.
+// Both secrets are gone: sessions, API keys and login codes are issued and
+// stored by the engine, so an empty environment is now a correct one and there
+// is no weak value left for an operator to supply.
+func TestValidateAcceptsEmptyConfig(t *testing.T) {
+	t.Parallel()
 
-	if err := cfg.Validate(); err != nil {
-		t.Fatalf("expected valid config, got error: %v", err)
-	}
-}
-
-func TestValidateRejectsWeakSecrets(t *testing.T) {
-	strongJWT := strings.Repeat("a", minJWTSecretLength)
-	strongIngest := strings.Repeat("b", minIngestTokenLength)
-
-	cases := []struct {
-		name        string
-		jwtSecret   string
-		ingestToken string
-		wantSubstr  string
-	}{
-		{"empty jwt secret", "", strongIngest, "JWT_SECRET"},
-		{"placeholder jwt secret", "change-me-in-production", strongIngest, "JWT_SECRET"},
-		{"short jwt secret", "too-short", strongIngest, "JWT_SECRET"},
-		{"empty ingest token", strongJWT, "", "RUNTZ_INGEST_TOKEN"},
-		{"placeholder ingest token", strongJWT, "dev-ingest-token", "RUNTZ_INGEST_TOKEN"},
-		{"short ingest token", strongJWT, "short", "RUNTZ_INGEST_TOKEN"},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			cfg := Config{JWTSecret: tc.jwtSecret, IngestToken: tc.ingestToken}
-			err := cfg.Validate()
-			if err == nil {
-				t.Fatal("expected validation error, got nil")
-			}
-			if !strings.Contains(err.Error(), tc.wantSubstr) {
-				t.Fatalf("expected error mentioning %q, got: %v", tc.wantSubstr, err)
-			}
-		})
+	if err := (Config{}).Validate(); err != nil {
+		t.Fatalf("expected an empty config to be valid, got error: %v", err)
 	}
 }

--- a/frontend/src/app/api/[...path]/route.ts
+++ b/frontend/src/app/api/[...path]/route.ts
@@ -30,6 +30,18 @@ async function proxy(request: NextRequest, context: RouteContext) {
   responseHeaders.delete("content-encoding")
   responseHeaders.delete("content-length")
 
+  // Set-Cookie has to survive this hop intact — it is what carries the session.
+  // The Headers constructor folds repeated headers into a single comma-joined
+  // value, which corrupts cookies whose attributes contain commas (Expires) and
+  // merges separate cookies into one, so re-emit each one on its own line.
+  const setCookies = response.headers.getSetCookie?.() ?? []
+  if (setCookies.length > 0) {
+    responseHeaders.delete("set-cookie")
+    for (const cookie of setCookies) {
+      responseHeaders.append("set-cookie", cookie)
+    }
+  }
+
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,

--- a/frontend/src/app/app/api-keys/page.tsx
+++ b/frontend/src/app/app/api-keys/page.tsx
@@ -44,7 +44,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-import { apiRequest, getStoredToken, type ApiKey } from "@/lib/api"
+import { apiRequest, type ApiKey } from "@/lib/api"
 
 const ALL_WORKSPACES = "all"
 
@@ -62,17 +62,12 @@ export default function APIKeysPage() {
     selectedWorkspaceId !== ALL_WORKSPACES ? selectedWorkspaceId : ""
 
   const loadAPIKeys = React.useCallback(async () => {
-    const token = getStoredToken()
-    if (!token) {
-      return
-    }
 
     const query = effectiveWorkspaceId
       ? `?workspaceId=${encodeURIComponent(effectiveWorkspaceId)}`
       : ""
     const response = await apiRequest<{ apiKeys: ApiKey[] }>(
-      `/api/v1/api-keys${query}`,
-      { token }
+      `/api/v1/api-keys${query}`
     )
     setAPIKeys(response.apiKeys ?? [])
   }, [effectiveWorkspaceId])
@@ -94,8 +89,7 @@ export default function APIKeysPage() {
 
   async function createAPIKey(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
-    const token = getStoredToken()
-    if (!token || !workspaceId) {
+    if (!workspaceId) {
       return
     }
 
@@ -106,7 +100,6 @@ export default function APIKeysPage() {
         "/api/v1/api-keys",
         {
           method: "POST",
-          token,
           body: { workspaceId, name, scopes: ["ingest:write"] },
         }
       )
@@ -122,17 +115,12 @@ export default function APIKeysPage() {
   }
 
   async function revokeAPIKey(apiKey: ApiKey) {
-    const token = getStoredToken()
-    if (!token) {
-      return
-    }
 
     setError("")
     setPending(true)
     try {
       await apiRequest(`/api/v1/api-keys/${apiKey.id}/revoke`, {
         method: "PATCH",
-        token,
       })
       await loadAPIKeys()
     } catch (error) {

--- a/frontend/src/app/app/onboarding/page.tsx
+++ b/frontend/src/app/app/onboarding/page.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { useWorkspace } from "@/components/runtz/workspace-context"
-import { apiRequest, getStoredToken, type ApiKey } from "@/lib/api"
+import { apiRequest, type ApiKey } from "@/lib/api"
 import { cn } from "@/lib/utils"
 
 const installCommand = "curl -fsSL https://runtz.dev/install.sh | bash"
@@ -43,8 +43,7 @@ export default function OnboardingPage() {
       : `runtz host --endpoint ${endpoint} --token ${tokenValue}`
 
   async function createAPIKey() {
-    const token = getStoredToken()
-    if (!token || !workspace) {
+    if (!workspace) {
       setError("Initial workspace not found.")
       return
     }
@@ -56,7 +55,6 @@ export default function OnboardingPage() {
         "/api/v1/api-keys",
         {
           method: "POST",
-          token,
           body: {
             workspaceId: workspace.id,
             name: "Onboarding CLI key",
@@ -80,8 +78,7 @@ export default function OnboardingPage() {
   }
 
   async function completeOnboarding() {
-    const token = getStoredToken()
-    if (!token || !apiKey) {
+    if (!apiKey) {
       return
     }
 
@@ -90,7 +87,6 @@ export default function OnboardingPage() {
     try {
       await apiRequest("/api/v1/me/onboarding", {
         method: "PATCH",
-        token,
       })
       router.replace("/app/overview")
     } catch (error) {
@@ -100,14 +96,9 @@ export default function OnboardingPage() {
   }
 
   async function skipOnboarding() {
-    const token = getStoredToken()
-    if (!token) {
-      router.replace("/app/overview")
-      return
-    }
     setPending(true)
     try {
-      await apiRequest("/api/v1/me/onboarding", { method: "PATCH", token })
+      await apiRequest("/api/v1/me/onboarding", { method: "PATCH" })
     } catch {
       // best-effort: navigate regardless
     } finally {

--- a/frontend/src/app/app/settings/page.tsx
+++ b/frontend/src/app/app/settings/page.tsx
@@ -59,7 +59,7 @@ import {
   TableRow,
 } from "@/components/ui/table"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { apiRequest, getStoredToken, type Entitlement, type User } from "@/lib/api"
+import { apiRequest, type Entitlement, type User } from "@/lib/api"
 
 type SettingsTab = "profile" | "workspaces" | "usage" | "billing" | "users"
 
@@ -176,17 +176,12 @@ function WorkspacesPanel() {
 
   async function createWorkspace(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
-    const token = getStoredToken()
-    if (!token) {
-      return
-    }
 
     setError("")
     setPending(true)
     try {
       await apiRequest("/api/v1/workspaces", {
         method: "POST",
-        token,
         body: { name },
       })
       setName("")
@@ -445,14 +440,8 @@ function UsersPanel() {
   const [pending, setPending] = React.useState(false)
 
   const loadUsers = React.useCallback(async () => {
-    const token = getStoredToken()
-    if (!token) {
-      return
-    }
 
-    const response = await apiRequest<{ users: User[] }>("/api/v1/users", {
-      token,
-    })
+    const response = await apiRequest<{ users: User[] }>("/api/v1/users")
     setUsers(response.users ?? [])
   }, [])
 
@@ -468,17 +457,12 @@ function UsersPanel() {
 
   async function createUser(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
-    const token = getStoredToken()
-    if (!token) {
-      return
-    }
 
     setError("")
     setPending(true)
     try {
       await apiRequest("/api/v1/users", {
         method: "POST",
-        token,
         body: {
           username,
           password,
@@ -499,28 +483,19 @@ function UsersPanel() {
   }
 
   async function togglePasswordChange(user: User) {
-    const token = getStoredToken()
-    if (!token) {
-      return
-    }
 
     await apiRequest(`/api/v1/users/${user.id}`, {
       method: "PATCH",
-      token,
       body: { requirePasswordChange: !user.requirePasswordChange },
     })
     await loadUsers()
   }
 
   async function createInvite(user: User) {
-    const token = getStoredToken()
-    if (!token) {
-      return
-    }
 
     const response = await apiRequest<{ inviteLink: string }>(
       `/api/v1/users/${user.id}/invite`,
-      { method: "POST", token }
+      { method: "POST" }
     )
     setInviteLink(response.inviteLink)
   }
@@ -742,10 +717,6 @@ function UsagePanel() {
   const [pending, setPending] = React.useState(true)
 
   const loadUsage = React.useCallback(async () => {
-    const token = getStoredToken()
-    if (!token) {
-      return
-    }
 
     setPending(true)
     setError("")
@@ -754,7 +725,7 @@ function UsagePanel() {
         selectedWorkspaceId && selectedWorkspaceId !== "all"
           ? `?workspaceId=${encodeURIComponent(selectedWorkspaceId)}`
           : ""
-      setUsage(await apiRequest<UsageResponse>(`/api/v1/usage${query}`, { token }))
+      setUsage(await apiRequest<UsageResponse>(`/api/v1/usage${query}`))
     } catch (error) {
       setError(error instanceof Error ? error.message : "Failed to load usage")
     } finally {
@@ -867,13 +838,7 @@ function BillingPanel() {
   const activatedSessionRef = React.useRef("")
 
   const loadStatus = React.useCallback(async () => {
-    const token = getStoredToken()
-    if (!token) {
-      return
-    }
-    const response = await apiRequest<BillingStatusResponse>("/api/v1/billing/status", {
-      token,
-    })
+    const response = await apiRequest<BillingStatusResponse>("/api/v1/billing/status")
     setStatus(response)
   }, [])
 
@@ -890,17 +855,12 @@ function BillingPanel() {
     }
     activatedSessionRef.current = sessionId
 
-    const token = getStoredToken()
-    if (!token) {
-      return
-    }
 
     setPending(true)
     setError("")
     setMessage("Activating license after payment confirmation...")
     apiRequest("/api/v1/license/checkout/activate", {
       method: "POST",
-      token,
       body: { sessionId },
     })
       .then(() => {
@@ -943,17 +903,12 @@ function BillingPanel() {
   }, [loadStatus])
 
   async function startCheckout(plan: "pro" | "enterprise") {
-    const token = getStoredToken()
-    if (!token) {
-      return
-    }
     setError("")
     setMessage("")
     setPending(true)
     try {
       const response = await apiRequest<{ url: string }>("/api/v1/billing/checkout", {
         method: "POST",
-        token,
         body: {
           plan,
           deploymentMode,
@@ -975,16 +930,11 @@ function BillingPanel() {
   }
 
   async function openPortal() {
-    const token = getStoredToken()
-    if (!token) {
-      return
-    }
     setError("")
     setPending(true)
     try {
       const response = await apiRequest<{ url: string }>("/api/v1/billing/portal", {
         method: "POST",
-        token,
         body: { returnUrl: window.location.origin + "/app/settings?tab=billing" },
       })
       window.location.assign(response.url)
@@ -996,17 +946,12 @@ function BillingPanel() {
   }
 
   async function refreshLicense() {
-    const token = getStoredToken()
-    if (!token) {
-      return
-    }
     setMessage("")
     setError("")
     setPending(true)
     try {
       await apiRequest("/api/v1/license/refresh", {
         method: "POST",
-        token,
       })
       setMessage("Heartbeat validated with the central engine.")
       await loadStatus()
@@ -1214,10 +1159,6 @@ function SelfHostedProfilePanel() {
 
   async function changePassword(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
-    const token = getStoredToken()
-    if (!token) {
-      return
-    }
 
     setMessage("")
     setError("")
@@ -1225,7 +1166,6 @@ function SelfHostedProfilePanel() {
     try {
       await apiRequest("/api/v1/me/password", {
         method: "PATCH",
-        token,
         body: { currentPassword, newPassword },
       })
       setCurrentPassword("")

--- a/frontend/src/app/checkout/page.tsx
+++ b/frontend/src/app/checkout/page.tsx
@@ -13,7 +13,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
-import { ApiError, apiRequest, clearToken, getStoredToken } from "@/lib/api"
+import { ApiError, apiRequest, clearClientState } from "@/lib/api"
 import type { Entitlement, User, Workspace } from "@/lib/api"
 import type { DeploymentMode } from "@/components/runtz/workspace-context"
 
@@ -93,15 +93,8 @@ function CheckoutFlow() {
     async function start() {
       const plan = normalizePlan(params.get("plan"))
       const deploymentMode = normalizeDeploymentMode(params.get("deploymentMode"))
-      const token = getStoredToken()
-
-      if (!token) {
-        router.replace(`/login?next=${encodeURIComponent(currentPathWithSearch())}`)
-        return
-      }
-
       try {
-        const response = await apiRequest<MeResponse>("/api/v1/me", { token })
+        const response = await apiRequest<MeResponse>("/api/v1/me")
         if (cancelled) {
           return
         }
@@ -153,7 +146,6 @@ function CheckoutFlow() {
 
         const checkout = await apiRequest<{ url: string }>("/api/v1/billing/checkout", {
           method: "POST",
-          token,
           body: {
             plan,
             deploymentMode,
@@ -169,7 +161,7 @@ function CheckoutFlow() {
         }
 
         if (error instanceof ApiError && error.status === 401) {
-          clearToken()
+          clearClientState()
           router.replace(`/login?next=${encodeURIComponent(currentPathWithSearch())}`)
           return
         }

--- a/frontend/src/app/login/github/callback/page.tsx
+++ b/frontend/src/app/login/github/callback/page.tsx
@@ -12,11 +12,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
-import { apiRequest, storeToken } from "@/lib/api"
-
-type AuthResponse = {
-  token: string
-}
+import { apiRequest } from "@/lib/api"
 
 function safeNextPath(value: string | null) {
   if (!value || !value.startsWith("/") || value.startsWith("//")) {
@@ -57,15 +53,14 @@ function GitHubCallback() {
       return
     }
 
-    apiRequest<AuthResponse>("/api/v1/auth/github", {
+    apiRequest("/api/v1/auth/github", {
       method: "POST",
       body: {
         code,
         redirectUri: `${window.location.origin}/login/github/callback`,
       },
     })
-      .then((response) => {
-        storeToken(response.token)
+      .then(() => {
         router.replace(nextPath)
       })
       .catch((requestError) => {

--- a/frontend/src/components/runtz/app-shell.tsx
+++ b/frontend/src/components/runtz/app-shell.tsx
@@ -47,8 +47,8 @@ import {
 import { Skeleton } from "@/components/ui/skeleton"
 import {
   apiRequest,
-  clearToken,
-  getStoredToken,
+  clearClientState,
+  signOut,
   type Entitlement,
   type User,
   type Workspace,
@@ -138,7 +138,7 @@ export function AppShell({
   const basePath = isPlayground ? "/playground" : "/app"
   const codeItems = React.useMemo(() => buildCodeItems(basePath), [basePath])
   const hostItems = React.useMemo(() => buildHostItems(basePath), [basePath])
-  const [token, setToken] = React.useState<string | null>(null)
+  const [authenticated, setAuthenticated] = React.useState(false)
   const [user, setUser] = React.useState<User | null>(null)
   const [workspaces, setWorkspaces] = React.useState<Workspace[]>([])
   const [deploymentMode, setDeploymentMode] =
@@ -159,14 +159,8 @@ export function AppShell({
       return
     }
 
-    const activeToken = getStoredToken()
-    if (!activeToken) {
-      return
-    }
-
     const response = await apiRequest<{ workspaces: Workspace[] }>(
-      "/api/v1/workspaces",
-      { token: activeToken }
+      "/api/v1/workspaces"
     )
     const workspaces = response.workspaces ?? []
     setWorkspaces(workspaces)
@@ -183,7 +177,7 @@ export function AppShell({
 
   React.useEffect(() => {
     if (isPlayground) {
-      setToken("playground")
+      setAuthenticated(true)
       setUser(PLAYGROUND_USER)
       setWorkspaces(PLAYGROUND_WORKSPACES)
       setEntitlement(FREE_SELF_HOSTED_ENTITLEMENT)
@@ -192,15 +186,11 @@ export function AppShell({
       return
     }
 
-    const activeToken = getStoredToken()
-    if (!activeToken) {
-      router.replace("/login")
-      return
-    }
-
-    setToken(activeToken)
-    apiRequest<MeResponse>("/api/v1/me", { token: activeToken })
+    // There is no token to inspect any more: whether the session cookie is
+    // still good is a question only the engine can answer, so ask it.
+    apiRequest<MeResponse>("/api/v1/me")
       .then((response) => {
+        setAuthenticated(true)
         setUser(response.user)
         setDeploymentMode(response.deploymentMode)
         setEntitlement(response.entitlement)
@@ -227,7 +217,7 @@ export function AppShell({
         }
       })
       .catch(() => {
-        clearToken()
+        clearClientState()
         router.replace("/login")
       })
       .finally(() => setLoading(false))
@@ -238,12 +228,12 @@ export function AppShell({
     window.localStorage.setItem(WORKSPACE_FILTER_KEY, workspaceId)
   }
 
-  function logout() {
-    clearToken()
+  async function logout() {
+    await signOut()
     router.replace("/login")
   }
 
-  if (loading || !token || !user) {
+  if (loading || !authenticated || !user) {
     return (
       <div className="flex min-h-svh items-center justify-center bg-background p-6">
         <div className="flex w-full max-w-sm flex-col gap-4">

--- a/frontend/src/components/runtz/setup-login.tsx
+++ b/frontend/src/components/runtz/setup-login.tsx
@@ -28,7 +28,7 @@ import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { RuntzWordmark } from "@/components/runtz/logo"
 import { ThemeToggle } from "@/components/runtz/theme-provider"
-import { apiRequest, clearToken, getStoredToken, storeToken } from "@/lib/api"
+import { apiRequest, clearClientState } from "@/lib/api"
 import { DEFAULT_GOOGLE_CLIENT_ID } from "@/lib/google"
 import { cn } from "@/lib/utils"
 
@@ -111,26 +111,20 @@ export function SetupLogin() {
       )
   }, [])
 
-  // The session token lives in localStorage, so a second tab (or coming back
-  // from the landing page) is still signed in — send it straight to the app
-  // instead of asking for the credentials again. A token the engine rejects is
-  // dropped here so the form is shown.
+  // A second tab (or coming back from the landing page) may still hold a
+  // valid session cookie — ask the engine and send it straight to the app
+  // instead of asking for credentials again. A rejected session falls through
+  // to the form.
   React.useEffect(() => {
-    const token = getStoredToken()
-    if (!token) {
-      setRestoringSession(false)
-      return
-    }
-
     let cancelled = false
-    apiRequest("/api/v1/me", { token })
+    apiRequest("/api/v1/me")
       .then(() => {
         if (!cancelled) {
           router.replace(nextPath)
         }
       })
       .catch(() => {
-        clearToken()
+        clearClientState()
         if (!cancelled) {
           setRestoringSession(false)
         }
@@ -212,11 +206,10 @@ function CloudLoginForm({
     setError("")
     setPending(true)
     try {
-      const response = await apiRequest<AuthResponse>("/api/v1/auth/google", {
+      await apiRequest<AuthResponse>("/api/v1/auth/google", {
         method: "POST",
         body: { credential },
       })
-      storeToken(response.token)
       onAuthenticated()
     } catch (error) {
       setError(
@@ -249,11 +242,10 @@ function CloudLoginForm({
     setError("")
     setPending(true)
     try {
-      const response = await apiRequest<AuthResponse>("/api/v1/auth/email/verify", {
+      await apiRequest<AuthResponse>("/api/v1/auth/email/verify", {
         method: "POST",
         body: { email, code },
       })
-      storeToken(response.token)
       onAuthenticated()
     } catch (error) {
       setError(error instanceof Error ? error.message : "Invalid code")
@@ -569,11 +561,10 @@ function SelfHostedLoginForm({
     setError("")
     setPending(true)
     try {
-      const response = await apiRequest<AuthResponse>("/api/v1/auth/login", {
+      await apiRequest<AuthResponse>("/api/v1/auth/login", {
         method: "POST",
         body: { username, password },
       })
-      storeToken(response.token)
       onAuthenticated()
     } catch (error) {
       setError(error instanceof Error ? error.message : "Sign-in failed")
@@ -635,11 +626,10 @@ function SetupForm({ onConfigured }: { onConfigured: () => void }) {
     setError("")
     setPending(true)
     try {
-      const response = await apiRequest<AuthResponse>("/api/v1/setup", {
+      await apiRequest<AuthResponse>("/api/v1/setup", {
         method: "POST",
         body: { username, password, workspaceName },
       })
-      storeToken(response.token)
       onConfigured()
     } catch (error) {
       setError(error instanceof Error ? error.message : "Setup failed")

--- a/frontend/src/components/runtz/use-finding-scans.ts
+++ b/frontend/src/components/runtz/use-finding-scans.ts
@@ -4,7 +4,7 @@ import * as React from "react"
 
 import { usePlatform } from "@/components/runtz/platform-context"
 import { useWorkspace } from "@/components/runtz/workspace-context"
-import { apiRequest, getStoredToken, type FindingsScan } from "@/lib/api"
+import { apiRequest, type FindingsScan } from "@/lib/api"
 import {
   loadPlaygroundScans,
   playgroundScansOfType,
@@ -37,12 +37,6 @@ export function useFindingScans(scanType: "sast" | "k8s") {
       return
     }
 
-    const token = getStoredToken()
-    if (!token) {
-      setScans([])
-      setLoading(false)
-      return
-    }
 
     setLoading(true)
     setError("")
@@ -51,7 +45,7 @@ export function useFindingScans(scanType: "sast" | "k8s") {
         ? `/api/v1/scans/${scanType}?workspaceId=${selectedWorkspaceId}`
         : `/api/v1/scans/${scanType}`
 
-    apiRequest<{ scans: FindingsScan[] }>(path, { token })
+    apiRequest<{ scans: FindingsScan[] }>(path)
       .then((response) => {
         setScans(response.scans ?? [])
       })

--- a/frontend/src/components/runtz/use-package-scans.ts
+++ b/frontend/src/components/runtz/use-package-scans.ts
@@ -4,7 +4,7 @@ import * as React from "react"
 
 import { usePlatform } from "@/components/runtz/platform-context"
 import { useWorkspace } from "@/components/runtz/workspace-context"
-import { apiRequest, getStoredToken, type PackageScan } from "@/lib/api"
+import { apiRequest, type PackageScan } from "@/lib/api"
 import {
   loadPlaygroundScans,
   playgroundScansOfType,
@@ -37,12 +37,6 @@ export function usePackageScans(scanType: "host" | "container") {
       return
     }
 
-    const token = getStoredToken()
-    if (!token) {
-      setScans([])
-      setLoading(false)
-      return
-    }
 
     setLoading(true)
     setError("")
@@ -51,7 +45,7 @@ export function usePackageScans(scanType: "host" | "container") {
         ? `/api/v1/scans/${scanType}?workspaceId=${selectedWorkspaceId}`
         : `/api/v1/scans/${scanType}`
 
-    apiRequest<{ scans: PackageScan[] }>(path, { token })
+    apiRequest<{ scans: PackageScan[] }>(path)
       .then((response) => {
         setScans(response.scans ?? [])
       })

--- a/frontend/src/components/runtz/use-sca-scans.ts
+++ b/frontend/src/components/runtz/use-sca-scans.ts
@@ -4,7 +4,7 @@ import * as React from "react"
 
 import { usePlatform } from "@/components/runtz/platform-context"
 import { useWorkspace } from "@/components/runtz/workspace-context"
-import { apiRequest, getStoredToken, type SCAScan } from "@/lib/api"
+import { apiRequest, type SCAScan } from "@/lib/api"
 import {
   loadPlaygroundScans,
   playgroundScansOfType,
@@ -35,12 +35,6 @@ export function useSCAScans() {
       return
     }
 
-    const token = getStoredToken()
-    if (!token) {
-      setScans([])
-      setLoading(false)
-      return
-    }
 
     const path =
       selectedWorkspaceId && selectedWorkspaceId !== "all"
@@ -48,7 +42,7 @@ export function useSCAScans() {
         : "/api/v1/scans/sca"
 
     setLoading(true)
-    apiRequest<{ scans: SCAScan[] }>(path, { token })
+    apiRequest<{ scans: SCAScan[] }>(path)
       .then((response) => {
         setScans(response.scans ?? [])
         setError("")

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -194,7 +194,6 @@ export type ContainerScan = PackageScan & {
 
 type RequestOptions = {
   method?: "GET" | "POST" | "PATCH"
-  token?: string | null
   body?: unknown
 }
 
@@ -211,11 +210,14 @@ export async function apiRequest<T>(
   path: string,
   options: RequestOptions = {}
 ): Promise<T> {
+  // The session rides in an HttpOnly cookie the browser attaches on its own —
+  // there is no token for this code to read, store or forward, which is the
+  // point: a script injected into the dashboard cannot reach the credential.
   const response = await fetch(`${API_URL}${path}`, {
     method: options.method ?? "GET",
+    credentials: "same-origin",
     headers: {
       "Content-Type": "application/json",
-      ...(options.token ? { Authorization: `Bearer ${options.token}` } : {}),
     },
     body: options.body ? JSON.stringify(options.body) : undefined,
   })
@@ -231,20 +233,25 @@ export async function apiRequest<T>(
   return payload as T
 }
 
-export function getStoredToken() {
+// clearClientState drops the local UI preferences tied to a signed-in user.
+// The session itself is not here to clear — it is an HttpOnly cookie only the
+// engine can set or expire, which is why signing out has to go through the API.
+export function clearClientState() {
   if (typeof window === "undefined") {
-    return null
+    return
   }
 
-  return window.localStorage.getItem("runtz_token")
-}
-
-export function storeToken(token: string) {
-  window.localStorage.setItem("runtz_token", token)
-}
-
-export function clearToken() {
-  window.localStorage.removeItem("runtz_token")
   window.localStorage.removeItem("runtz_workspace_id")
   window.localStorage.removeItem("runtz_workspace_filter")
+}
+
+export async function signOut() {
+  try {
+    await apiRequest("/api/v1/auth/logout", { method: "POST" })
+  } catch {
+    // The local state has to go even if the engine is unreachable; the cookie
+    // expires on its own and the session row with it.
+  }
+
+  clearClientState()
 }

--- a/helm/environments/README.md
+++ b/helm/environments/README.md
@@ -57,13 +57,13 @@ kubectl -n <namespace> rollout restart deployment runtz-backend
 
 ## Recommended: secrets as a Kubernetes Secret
 
-The engine Deployment reads **all seven keys** from the Secret — every key
-must exist (use an empty string for features you don't use):
+The engine Deployment reads **all five keys** from the Secret — every key
+must exist (use an empty string for features you don't use). None of them are
+required to run: sessions, API keys and login codes are issued and stored by
+the engine itself.
 
 | Key | Purpose | How to obtain |
 | --- | --- | --- |
-| `JWT_SECRET` | Session tokens (required) | `openssl rand -base64 32` |
-| `RUNTZ_INGEST_TOKEN` | Shared ingest token (required) | `openssl rand -base64 24` |
 | `RESEND_API_KEY` | Email sign-in codes / invites | Resend dashboard |
 | `GITHUB_CLIENT_SECRET` | GitHub OAuth login | GitHub OAuth app settings |
 | `STRIPE_SECRET_KEY` | Billing (central engine only) | Stripe dashboard → API keys |
@@ -73,8 +73,6 @@ must exist (use an empty string for features you don't use):
 ```bash
 kubectl create secret generic runtz-engine-secrets \
   --namespace <namespace> \
-  --from-literal=JWT_SECRET="$(openssl rand -base64 32)" \
-  --from-literal=RUNTZ_INGEST_TOKEN="$(openssl rand -base64 24)" \
   --from-literal=RESEND_API_KEY="re_..." \
   --from-literal=GITHUB_CLIENT_SECRET="..." \
   --from-literal=STRIPE_SECRET_KEY="sk_live_..." \

--- a/helm/runtz/README.md
+++ b/helm/runtz/README.md
@@ -9,10 +9,7 @@ and an optional in-cluster MongoDB.
 helm repo add runtz https://helm.runtz.dev
 helm repo update
 
-cp values.secrets.example.yaml values.secrets.yaml
-# fill jwtSecret and ingestToken (see the file's comments)
-
-helm install runtz runtz/runtz -f values.secrets.yaml
+helm install runtz runtz/runtz
 ```
 
 Without an ingress, reach the platform with a port-forward:
@@ -23,20 +20,17 @@ kubectl port-forward svc/runtz-frontend 3000:3000
 
 Open http://localhost:3000 and create the admin user on first access.
 
-## Required secrets
+## Secrets
 
-The engine refuses to start with empty or placeholder secrets:
-
-| Value | Generate with |
-| --- | --- |
-| `backend.secrets.jwtSecret` | `openssl rand -base64 32` |
-| `backend.secrets.ingestToken` | `openssl rand -base64 24` |
+None are required — the engine issues and stores its own sessions, API keys
+and login codes. Secrets only enable optional integrations: `resendApiKey`
+(email login), `githubClientSecret` (OAuth), `stripeSecretKey` /
+`stripeWebhookSecret` (billing) and `licensePrivateKey` (central engine only).
 
 Alternatively, set `backend.secrets.existingSecret` to the name of a
-pre-created Kubernetes Secret containing the keys `JWT_SECRET`,
-`RUNTZ_INGEST_TOKEN`, `RESEND_API_KEY`, `GITHUB_CLIENT_SECRET`,
-`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` and `RUNTZ_LICENSE_PRIVATE_KEY`
-(empty strings for unused ones).
+pre-created Kubernetes Secret containing the keys `RESEND_API_KEY`,
+`GITHUB_CLIENT_SECRET`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` and
+`RUNTZ_LICENSE_PRIVATE_KEY` (empty strings for unused ones).
 
 ## Common values
 

--- a/helm/runtz/templates/NOTES.txt
+++ b/helm/runtz/templates/NOTES.txt
@@ -30,5 +30,7 @@ MongoDB persists to a StatefulSet PVC
 {{- end }}.
 {{- end }}
 
-Secrets (JWT_SECRET, RUNTZ_INGEST_TOKEN, ...) come from values.secrets.yaml or
-an existing Secret — see values.secrets.example.yaml in the chart sources.
+No secrets are needed to run: the engine issues and stores its own sessions,
+API keys and login codes. Optional integrations (OAuth, email login, Stripe)
+take their secrets from values.secrets.yaml or an existing Secret — see
+values.secrets.example.yaml in the chart sources.

--- a/helm/runtz/templates/engine/deployment.yaml
+++ b/helm/runtz/templates/engine/deployment.yaml
@@ -52,16 +52,6 @@ spec:
                 name: {{ . }}
             {{- end }}
           env:
-            - name: JWT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "runtz.backendSecretName" . }}
-                  key: JWT_SECRET
-            - name: RUNTZ_INGEST_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "runtz.backendSecretName" . }}
-                  key: RUNTZ_INGEST_TOKEN
             - name: RESEND_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/helm/runtz/templates/engine/secret.yaml
+++ b/helm/runtz/templates/engine/secret.yaml
@@ -7,8 +7,6 @@ metadata:
     {{- include "runtz.componentLabels" (dict "root" . "component" "backend") | nindent 4 }}
 type: Opaque
 data:
-  JWT_SECRET: {{ default "" .Values.backend.secrets.jwtSecret | b64enc | quote }}
-  RUNTZ_INGEST_TOKEN: {{ default "" .Values.backend.secrets.ingestToken | b64enc | quote }}
   RESEND_API_KEY: {{ default "" .Values.backend.secrets.resendApiKey | b64enc | quote }}
   GITHUB_CLIENT_SECRET: {{ default "" .Values.backend.secrets.githubClientSecret | b64enc | quote }}
   STRIPE_SECRET_KEY: {{ default "" .Values.backend.secrets.stripeSecretKey | b64enc | quote }}

--- a/helm/runtz/values.secrets.example.yaml
+++ b/helm/runtz/values.secrets.example.yaml
@@ -2,13 +2,10 @@
 # values.secrets.yaml and fill the real values locally.
 # Keep values.secrets.yaml out of git — it is ignored by git and by Helm packaging.
 #
-# Required (the engine refuses to start with empty or placeholder values):
-#   jwtSecret    generate with: openssl rand -base64 32
-#   ingestToken  generate with: openssl rand -base64 24
+# Everything here is optional — the chart installs without any of it. These
+# only enable integrations: email login, OAuth and billing.
 backend:
   secrets:
-    jwtSecret: ""
-    ingestToken: ""
     resendApiKey: ""
     githubClientSecret: ""
     stripeSecretKey: ""

--- a/helm/runtz/values.yaml
+++ b/helm/runtz/values.yaml
@@ -3,12 +3,14 @@
 # These defaults deploy a self-contained, self-hosted runtz stack (engine,
 # frontend and MongoDB) using the public Docker Hub images.
 #
-# Required before installing: create a values.secrets.yaml from
-# values.secrets.example.yaml and set backend.secrets.jwtSecret and
-# backend.secrets.ingestToken (the engine refuses to start without them):
+# No secrets are required to install: the engine issues and stores its own
+# sessions, API keys and login codes.
 #
 #   helm repo add runtz https://helm.runtz.dev
-#   helm install runtz runtz/runtz -f values.secrets.yaml
+#   helm install runtz runtz/runtz
+#
+# Optional integrations (OAuth, email login, Stripe) still take secrets —
+# see values.secrets.example.yaml.
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
## What does this PR do?

Removes `JWT_SECRET` and `RUNTZ_INGEST_TOKEN` entirely, so the self-hosted quickstart is `docker compose up -d` and `helm install runtz runtz/runtz` with nothing to generate. Neither secret was needed: sessions, API keys and login codes are credentials the engine can issue and store itself.

Along the way it closes four things the secrets never covered:

| | Before | After |
|---|---|---|
| Session in `localStorage`, 7d, irrevocable | XSS = account takeover | HttpOnly cookie, revocable |
| Logout | did not exist | `POST /api/v1/auth/logout` |
| Cross-tenant ingest on the central engine | one env var away | impossible — workspace comes from the API key |
| Password login rate limit | none at all | 10 attempts, 1h lockout |
| Cloud `admin` reading other tenants' scans | allowed by code | scoped to membership |

**Breaking:** everyone is signed out once, and CI must use an `rtz_...` API key in `RUNTZ_TOKEN`. See the CHANGELOG entry.

Sessions are opaque 256-bit tokens stored as SHA-256 in a new `sessions` collection with a TTL index — the same shape as `api_keys`, which already worked this way. The cookie is first-party because the browser already reaches the engine same-origin through the frontend proxy, so no `SameSite=None` and no HTTPS requirement in development.

## Base branch

- [x] This PR targets `dev` (or is a release promotion to `main`)

## Checklist

- [x] `cd engine && go test ./...` passes
- [x] `cd frontend && npm run lint && npm run build` passes (if frontend changed)
- [x] `helm lint helm/runtz` passes (if chart changed)
- [x] No secrets, tokens or personal endpoints in the diff
- [x] Docs updated (README / site docs) if behavior changed

## Generated by

- **Author:** Claude (claude-opus-5)
- **Task / prompt:** Started as "why does the install command need this openssl token?" and became: remove the ingest token, replace JWT sessions with opaque cookie-backed ones, rate limit password login, stop the cloud admin role from widening data access, and update compose/chart/docs to match.
- **How it was verified:** `go test ./... && go vet ./...` and `gofmt` clean; `npm run lint && npm run build` on the frontend; `helm lint` plus `helm template` inspected to confirm no removed keys render; `docker compose config` on both the repo and the published copy. New tests cover the deployment-mode data scope, the lockout key namespacing and the bcrypt code binding.
- [ ] A human reviewed the full diff and takes responsibility for it

> **Not verified by me:** the `Set-Cookie` hop through the Next proxy needs a real browser — please exercise login → refresh → logout before this reaches prod.

By submitting this pull request, I agree that my contribution is provided
under the project license (BUSL-1.1) as described in CONTRIBUTING.md.