### PR TITLE
Group package CVEs and speed up scan views

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ follow `1.0.0-rc1 → 1.0.0-rc2 → ... → 1.0.0`, then regular semver
 - `GET /api/v1/scans/k8s`
 - `GET /api/v1/scans/k8s/{id}`
 
+Scan collection endpoints return lightweight metadata and the precomputed
+summary for dashboards. Use the corresponding `/{id}` endpoint when the full
+dependencies, packages, vulnerabilities or findings payload is needed. Detail
+views may request `/{id}?view=results` to receive only the finding/CVE result
+array without the scanned inventory.
+
 ## Community
 
 - [Contributing](CONTRIBUTING.md)

--- a/engine/internal/api/server.go
+++ b/engine/internal/api/server.go
@@ -190,7 +190,8 @@ func (s *Server) ensureIndexes(ctx context.Context) error {
 
 	_, err = s.scans.Indexes().CreateMany(ctx, []mongo.IndexModel{
 		{Keys: bson.D{{Key: "created_at", Value: -1}}},
-		{Keys: bson.D{{Key: "workspace_id", Value: 1}, {Key: "type", Value: 1}}},
+		{Keys: bson.D{{Key: "type", Value: 1}, {Key: "created_at", Value: -1}}},
+		{Keys: bson.D{{Key: "workspace_id", Value: 1}, {Key: "type", Value: 1}, {Key: "created_at", Value: -1}}},
 		{Keys: bson.D{{Key: "workspace_id", Value: 1}, {Key: "source", Value: 1}, {Key: "type", Value: 1}, {Key: "created_at", Value: -1}}},
 	})
 	if err != nil {
@@ -1049,10 +1050,22 @@ func (s *Server) handleListScansByType(w http.ResponseWriter, r *http.Request, s
 		filter["workspace_id"] = bson.M{"$in": user.WorkspaceIDs}
 	}
 
+	// List views only need scan metadata and the precomputed summary. Excluding
+	// the result arrays is especially important for host scans, where a single
+	// inventory may contain thousands of packages and CVEs. The full document
+	// remains available from GET /api/v1/scans/{type}/{id}.
 	cursor, err := s.scans.Find(
 		r.Context(),
 		filter,
-		options.Find().SetSort(bson.D{{Key: "created_at", Value: -1}}).SetLimit(50),
+		options.Find().
+			SetProjection(bson.M{
+				"dependencies":    0,
+				"packages":        0,
+				"findings":        0,
+				"vulnerabilities": 0,
+			}).
+			SetSort(bson.D{{Key: "created_at", Value: -1}}).
+			SetLimit(50),
 	)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list scans")
@@ -1097,8 +1110,26 @@ func (s *Server) handleGetScanByType(w http.ResponseWriter, r *http.Request, sca
 		return
 	}
 
+	findOptions := options.FindOne()
+	if r.URL.Query().Get("view") == "results" {
+		projection := bson.M{
+			"dependencies": 0,
+			"packages":     0,
+		}
+		if scanType == "sast" || scanType == "k8s" {
+			projection["vulnerabilities"] = 0
+		} else {
+			projection["findings"] = 0
+		}
+		findOptions.SetProjection(projection)
+	}
+
 	var scan Scan
-	if err := s.scans.FindOne(r.Context(), bson.M{"_id": scanID, "type": scanType}).Decode(&scan); err != nil {
+	if err := s.scans.FindOne(
+		r.Context(),
+		bson.M{"_id": scanID, "type": scanType},
+		findOptions,
+	).Decode(&scan); err != nil {
 		writeError(w, http.StatusNotFound, "scan not found")
 		return
 	}

--- a/frontend/src/app/app/containers/[imageName]/page.tsx
+++ b/frontend/src/app/app/containers/[imageName]/page.tsx
@@ -6,14 +6,17 @@ import { ArrowLeftIcon, ContainerIcon } from "lucide-react"
 import * as React from "react"
 
 import {
-  CVETable,
   DashboardSummaryGrid,
   LatestScansCard,
   MetricCard,
+  ScanDetailError,
+  ScanDetailSkeleton,
   VulnerabilityTrendChart,
 } from "@/components/runtz/sca-components"
+import { PackageVulnerabilityExplorer } from "@/components/runtz/package-vulnerability-explorer"
 import { usePlatform } from "@/components/runtz/platform-context"
 import { usePackageScans } from "@/components/runtz/use-package-scans"
+import { useScanDetail } from "@/components/runtz/use-scan-detail"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -51,6 +54,7 @@ export default function ContainerDetailPage() {
   )
   const latestScan = imageScans[0]
   const latestSummary = latestScan?.summary
+  const scanDetail = useScanDetail("container", latestScan)
 
   return (
     <div className="flex flex-col gap-6 p-4 md:p-6">
@@ -145,7 +149,20 @@ export default function ContainerDetailPage() {
                 </CardDescription>
               </CardHeader>
               <CardContent>
-                <CVETable vulnerabilities={latestScan.vulnerabilities} />
+                {scanDetail.loading ? (
+                  <ScanDetailSkeleton />
+                ) : scanDetail.error ? (
+                  <ScanDetailError message={scanDetail.error} />
+                ) : scanDetail.scan ? (
+                  <PackageVulnerabilityExplorer
+                    vulnerabilities={scanDetail.scan.vulnerabilities ?? []}
+                    targetKind="container"
+                    targetName={imageName}
+                    osName={latestScan.osName}
+                    osVersion={latestScan.osVersion}
+                    packageManager={latestScan.packageManager}
+                  />
+                ) : null}
               </CardContent>
             </Card>
 

--- a/frontend/src/app/app/hosts/[hostname]/page.tsx
+++ b/frontend/src/app/app/hosts/[hostname]/page.tsx
@@ -6,14 +6,17 @@ import { ArrowLeftIcon, ServerIcon } from "lucide-react"
 import * as React from "react"
 
 import {
-  CVETable,
   DashboardSummaryGrid,
   LatestScansCard,
   MetricCard,
+  ScanDetailError,
+  ScanDetailSkeleton,
   VulnerabilityTrendChart,
 } from "@/components/runtz/sca-components"
+import { PackageVulnerabilityExplorer } from "@/components/runtz/package-vulnerability-explorer"
 import { usePlatform } from "@/components/runtz/platform-context"
 import { usePackageScans } from "@/components/runtz/use-package-scans"
+import { useScanDetail } from "@/components/runtz/use-scan-detail"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -51,6 +54,7 @@ export default function HostDetailPage() {
   )
   const latestScan = hostScans[0]
   const latestSummary = latestScan?.summary
+  const scanDetail = useScanDetail("host", latestScan)
 
   return (
     <div className="flex flex-col gap-6 p-4 md:p-6">
@@ -145,7 +149,20 @@ export default function HostDetailPage() {
                 </CardDescription>
               </CardHeader>
               <CardContent>
-                <CVETable vulnerabilities={latestScan.vulnerabilities} />
+                {scanDetail.loading ? (
+                  <ScanDetailSkeleton />
+                ) : scanDetail.error ? (
+                  <ScanDetailError message={scanDetail.error} />
+                ) : scanDetail.scan ? (
+                  <PackageVulnerabilityExplorer
+                    vulnerabilities={scanDetail.scan.vulnerabilities ?? []}
+                    targetKind="host"
+                    targetName={hostname}
+                    osName={latestScan.osName}
+                    osVersion={latestScan.osVersion}
+                    packageManager={latestScan.packageManager}
+                  />
+                ) : null}
               </CardContent>
             </Card>
 

--- a/frontend/src/app/app/sca/[projectName]/page.tsx
+++ b/frontend/src/app/app/sca/[projectName]/page.tsx
@@ -6,13 +6,16 @@ import { ArrowLeftIcon, RadarIcon } from "lucide-react"
 import * as React from "react"
 
 import {
-  CVETable,
   DashboardSummaryGrid,
   LatestScansCard,
   MetricCard,
+  ScanDetailError,
+  ScanDetailSkeleton,
   VulnerabilityTrendChart,
 } from "@/components/runtz/sca-components"
+import { PackageVulnerabilityExplorer } from "@/components/runtz/package-vulnerability-explorer"
 import { usePlatform } from "@/components/runtz/platform-context"
+import { useScanDetail } from "@/components/runtz/use-scan-detail"
 import { useSCAScans } from "@/components/runtz/use-sca-scans"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -47,6 +50,7 @@ export default function SCAProjectPage() {
   )
   const latestScan = projectScans[0]
   const latestSummary = latestScan?.summary
+  const scanDetail = useScanDetail("sca", latestScan)
 
   return (
     <div className="flex flex-col gap-6 p-4 md:p-6">
@@ -141,7 +145,17 @@ export default function SCAProjectPage() {
                 </CardDescription>
               </CardHeader>
               <CardContent>
-                <CVETable vulnerabilities={latestScan.vulnerabilities} />
+                {scanDetail.loading ? (
+                  <ScanDetailSkeleton />
+                ) : scanDetail.error ? (
+                  <ScanDetailError message={scanDetail.error} />
+                ) : scanDetail.scan ? (
+                  <PackageVulnerabilityExplorer
+                    vulnerabilities={scanDetail.scan.vulnerabilities ?? []}
+                    targetKind="application"
+                    targetName={projectName}
+                  />
+                ) : null}
               </CardContent>
             </Card>
 

--- a/frontend/src/components/runtz/findings-target-page.tsx
+++ b/frontend/src/components/runtz/findings-target-page.tsx
@@ -12,10 +12,13 @@ import {
   DashboardSummaryGrid,
   LatestScansCard,
   MetricCard,
+  ScanDetailError,
+  ScanDetailSkeleton,
   VulnerabilityTrendChart,
 } from "@/components/runtz/sca-components"
 import { usePlatform } from "@/components/runtz/platform-context"
 import { useFindingScans } from "@/components/runtz/use-finding-scans"
+import { useScanDetail } from "@/components/runtz/use-scan-detail"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -79,15 +82,16 @@ export function FindingsTargetPage({
   )
   const latestScan = targetScans[0]
   const latestSummary = latestScan?.summary
+  const scanDetail = useScanDetail(scanType, latestScan)
   const latestFindings = React.useMemo(
     () =>
-      latestScan
-        ? (latestScan.findings ?? []).map((finding) => ({
-            scan: latestScan,
+      scanDetail.scan
+        ? (scanDetail.scan.findings ?? []).map((finding) => ({
+            scan: scanDetail.scan!,
             finding,
           }))
         : [],
-    [latestScan]
+    [scanDetail.scan]
   )
   const unit = inspectedLabel(scanType)
 
@@ -207,16 +211,30 @@ export function FindingsTargetPage({
           <VulnerabilityTrendChart scans={targetScans} />
 
           <div className="grid gap-6 xl:grid-cols-[1fr_360px]">
-            <FindingsTable
-              scans={[latestScan]}
-              findings={visibleFindings}
-              title="Findings encontrados"
-              description={
-                disabledCategories.size > 0
-                  ? `Exibindo ${visibleFindings.length} de ${latestFindings.length} findings · Último scan em ${formatDate(latestScan.createdAt)}`
-                  : `Último scan em ${formatDate(latestScan.createdAt)}`
-              }
-            />
+            {scanDetail.loading ? (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Findings encontrados</CardTitle>
+                  <CardDescription>Carregando o último scan…</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <ScanDetailSkeleton />
+                </CardContent>
+              </Card>
+            ) : scanDetail.error ? (
+              <ScanDetailError message={scanDetail.error} />
+            ) : scanDetail.scan ? (
+              <FindingsTable
+                scans={[scanDetail.scan]}
+                findings={visibleFindings}
+                title="Findings encontrados"
+                description={
+                  disabledCategories.size > 0
+                    ? `Exibindo ${visibleFindings.length} de ${latestFindings.length} findings · Último scan em ${formatDate(latestScan.createdAt)}`
+                    : `Último scan em ${formatDate(latestScan.createdAt)}`
+                }
+              />
+            ) : null}
 
             <div className="flex flex-col gap-6">
               <ScanTypeFilter

--- a/frontend/src/components/runtz/package-vulnerability-explorer.tsx
+++ b/frontend/src/components/runtz/package-vulnerability-explorer.tsx
@@ -1,0 +1,504 @@
+"use client"
+
+import {
+  CheckIcon,
+  ChevronRightIcon,
+  CopyIcon,
+  ExternalLinkIcon,
+  PackageIcon,
+  ShieldCheckIcon,
+  SparklesIcon,
+} from "lucide-react"
+import * as React from "react"
+
+import { SeverityBadge } from "@/components/runtz/sca-components"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty"
+import { Separator } from "@/components/ui/separator"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import type { Vulnerability } from "@/lib/api"
+import {
+  buildRemediationPrompt,
+  groupVulnerabilitiesByPackage,
+  referenceLabel,
+  vulnerabilityReferences,
+  type PackageVulnerabilityGroup,
+  type RemediationContext,
+} from "@/lib/package-vulnerabilities"
+
+type PackageVulnerabilityExplorerProps = RemediationContext & {
+  vulnerabilities: Vulnerability[]
+}
+
+export function PackageVulnerabilityExplorer({
+  vulnerabilities,
+  targetName,
+  targetKind,
+  osName,
+  osVersion,
+  packageManager,
+}: PackageVulnerabilityExplorerProps) {
+  const groups = React.useMemo(
+    () => groupVulnerabilitiesByPackage(vulnerabilities),
+    [vulnerabilities]
+  )
+  const [selectedKey, setSelectedKey] = React.useState<string>()
+  const lastTriggerRef = React.useRef<HTMLButtonElement | null>(null)
+  const selectedGroup = React.useMemo(
+    () => groups.find((group) => group.key === selectedKey),
+    [groups, selectedKey]
+  )
+
+  if (groups.length === 0) {
+    return (
+      <Empty className="min-h-48 border">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <ShieldCheckIcon />
+          </EmptyMedia>
+          <EmptyTitle>Nenhuma vulnerabilidade encontrada</EmptyTitle>
+          <EmptyDescription>
+            O último scan não retornou CVEs para as versões identificadas.
+          </EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    )
+  }
+
+  const context = {
+    targetName,
+    targetKind,
+    osName,
+    osVersion,
+    packageManager,
+  }
+
+  function selectPackage(
+    groupKey: string,
+    event: React.MouseEvent<HTMLButtonElement>
+  ) {
+    lastTriggerRef.current = event.currentTarget
+    setSelectedKey(groupKey)
+  }
+
+  function handleOpenChange(open: boolean) {
+    if (open) {
+      return
+    }
+    setSelectedKey(undefined)
+    window.requestAnimationFrame(() => lastTriggerRef.current?.focus())
+  }
+
+  return (
+    <>
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+        <span>
+          {vulnerabilities.length} ocorrências consolidadas em {groups.length}{" "}
+          {groups.length === 1 ? "pacote" : "pacotes"}
+        </span>
+        <span>Selecione um pacote para investigar e corrigir</span>
+      </div>
+
+      <div className="hidden md:block">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Pacote</TableHead>
+              <TableHead>CVEs</TableHead>
+              <TableHead>Maior severidade</TableHead>
+              <TableHead>Versão instalada</TableHead>
+              <TableHead>Correção</TableHead>
+              <TableHead>
+                <span className="sr-only">Abrir detalhes</span>
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {groups.map((group) => (
+              <TableRow key={group.key}>
+                <TableCell className="min-w-56">
+                  <Button
+                    variant="link"
+                    className="h-auto max-w-72 justify-start whitespace-normal px-0 py-1 text-left"
+                    onClick={(event) => selectPackage(group.key, event)}
+                  >
+                    <PackageIcon data-icon="inline-start" />
+                    <span className="break-all">{group.name}</span>
+                  </Button>
+                  <PackageOrigin group={group} />
+                </TableCell>
+                <TableCell>
+                  <Badge variant="secondary">
+                    {group.vulnerabilities.length}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  <SeverityBadge severity={group.highestSeverity} />
+                </TableCell>
+                <TableCell className="max-w-56 whitespace-normal">
+                  {formatValues(group.installedVersions)}
+                </TableCell>
+                <TableCell>
+                  <FixCoverage group={group} />
+                </TableCell>
+                <TableCell className="text-right">
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label={`Abrir detalhes de ${group.name}`}
+                    onClick={(event) => selectPackage(group.key, event)}
+                  >
+                    <ChevronRightIcon data-icon="inline-end" />
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="flex flex-col divide-y md:hidden">
+        {groups.map((group) => (
+          <Button
+            key={group.key}
+            variant="ghost"
+            className="h-auto w-full justify-start rounded-none px-2 py-4 text-left whitespace-normal"
+            onClick={(event) => selectPackage(group.key, event)}
+          >
+            <span className="flex min-w-0 flex-1 items-start gap-3">
+              <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-primary">
+                <PackageIcon data-icon="inline-start" />
+              </span>
+              <span className="flex min-w-0 flex-1 flex-col gap-2">
+                <span className="flex items-start justify-between gap-3">
+                  <span className="break-all font-medium">{group.name}</span>
+                  <ChevronRightIcon
+                    data-icon="inline-end"
+                    className="shrink-0"
+                  />
+                </span>
+                <PackageOrigin group={group} />
+                <span className="flex flex-wrap items-center gap-2">
+                  <Badge variant="secondary">
+                    {group.vulnerabilities.length} CVEs
+                  </Badge>
+                  <SeverityBadge severity={group.highestSeverity} />
+                  <FixCoverage group={group} />
+                </span>
+              </span>
+            </span>
+          </Button>
+        ))}
+      </div>
+
+      <Sheet
+        open={Boolean(selectedGroup)}
+        onOpenChange={handleOpenChange}
+      >
+        {selectedGroup ? (
+          <PackageDetailSheet group={selectedGroup} context={context} />
+        ) : null}
+      </Sheet>
+    </>
+  )
+}
+
+function PackageDetailSheet({
+  group,
+  context,
+}: {
+  group: PackageVulnerabilityGroup
+  context: RemediationContext
+}) {
+  const [copyStatus, setCopyStatus] = React.useState<
+    "idle" | "copied" | "error"
+  >("idle")
+  const prompt = React.useMemo(
+    () => buildRemediationPrompt(group, context),
+    [context, group]
+  )
+
+  async function copyPrompt() {
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(prompt)
+      } else {
+        fallbackCopy(prompt)
+      }
+      setCopyStatus("copied")
+      window.setTimeout(() => setCopyStatus("idle"), 1800)
+    } catch {
+      try {
+        fallbackCopy(prompt)
+        setCopyStatus("copied")
+        window.setTimeout(() => setCopyStatus("idle"), 1800)
+      } catch {
+        setCopyStatus("error")
+      }
+    }
+  }
+
+  return (
+    <SheetContent className="gap-0 overflow-y-auto data-[side=right]:w-full data-[side=right]:sm:max-w-2xl">
+      <SheetHeader className="border-b px-5 py-5 pr-14 sm:px-6 sm:py-6 sm:pr-16">
+        <div className="mb-2 flex items-center gap-2">
+          <Badge variant="outline">PACOTE</Badge>
+          <SeverityBadge severity={group.highestSeverity} />
+        </div>
+        <SheetTitle className="break-all text-xl">{group.name}</SheetTitle>
+        <SheetDescription>
+          {group.vulnerabilities.length}{" "}
+          {group.vulnerabilities.length === 1
+            ? "vulnerabilidade consolidada"
+            : "vulnerabilidades consolidadas"}
+          {group.installedVersions.length > 0
+            ? ` · versão ${group.installedVersions.join(", ")}`
+            : ""}
+        </SheetDescription>
+      </SheetHeader>
+
+      <div className="grid grid-cols-2 border-b sm:grid-cols-4">
+        <PackageMetric label="CVEs" value={group.vulnerabilities.length} />
+        <PackageMetric label="Com fix" value={group.fixableCount} />
+        <PackageMetric
+          label="Ecossistema"
+          value={formatValues(group.ecosystems)}
+        />
+        <PackageMetric
+          label="Source"
+          value={formatValues(group.sourcePackages)}
+        />
+      </div>
+
+      <div className="flex flex-col gap-6 px-5 py-6 sm:px-6">
+        <section aria-labelledby="ai-remediation-title">
+          <div className="mb-3 flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h2
+                id="ai-remediation-title"
+                className="flex items-center gap-2 font-medium"
+              >
+                <SparklesIcon className="size-4 text-primary" />
+                Prompt de remediação com IA
+              </h2>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Contextualizado com pacote, versões, CVEs, referências e plano de
+                rollback.
+              </p>
+            </div>
+            <Button variant="outline" size="sm" onClick={copyPrompt}>
+              {copyStatus === "copied" ? (
+                <CheckIcon data-icon="inline-start" />
+              ) : (
+                <CopyIcon data-icon="inline-start" />
+              )}
+              <span aria-live="polite">
+                {copyStatus === "copied"
+                  ? "Copiado"
+                  : copyStatus === "error"
+                    ? "Tente novamente"
+                    : "Copiar prompt"}
+              </span>
+            </Button>
+          </div>
+          <pre
+            className="max-h-72 overflow-auto rounded-lg border bg-muted/50 p-4 font-mono text-xs leading-relaxed whitespace-pre-wrap break-words"
+            tabIndex={0}
+            aria-label="Prompt de remediação"
+          >
+            {prompt}
+          </pre>
+        </section>
+
+        <Separator />
+
+        <section aria-labelledby="package-cves-title">
+          <div className="mb-3">
+            <h2 id="package-cves-title" className="font-medium">
+              Vulnerabilidades do pacote
+            </h2>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Ordenadas por severidade, com todas as referências recebidas no
+              scan.
+            </p>
+          </div>
+          <div className="flex flex-col divide-y rounded-lg border">
+            {group.vulnerabilities.map((vulnerability) => (
+              <VulnerabilityDetail
+                key={`${group.key}-${vulnerability.id}`}
+                vulnerability={vulnerability}
+              />
+            ))}
+          </div>
+        </section>
+      </div>
+    </SheetContent>
+  )
+}
+
+function VulnerabilityDetail({
+  vulnerability,
+}: {
+  vulnerability: Vulnerability
+}) {
+  const references = vulnerabilityReferences(vulnerability)
+
+  return (
+    <article className="flex flex-col gap-3 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-mono text-sm font-medium">
+            {vulnerability.id}
+          </span>
+          <SeverityBadge severity={vulnerability.severity} />
+          {vulnerability.cvssScore ? (
+            <Badge variant="outline">CVSS {vulnerability.cvssScore}</Badge>
+          ) : null}
+        </div>
+        {vulnerability.firstPatchedVersion ? (
+          <Badge variant="secondary">
+            Fix {vulnerability.firstPatchedVersion}
+          </Badge>
+        ) : (
+          <Badge variant="outline">Fix não publicado</Badge>
+        )}
+      </div>
+
+      <p className="text-sm leading-relaxed whitespace-pre-wrap">
+        {vulnerability.summary || "Resumo não informado."}
+      </p>
+
+      <dl className="grid gap-3 text-xs sm:grid-cols-3">
+        <div className="flex flex-col gap-1">
+          <dt className="text-muted-foreground">Instalada</dt>
+          <dd className="break-all font-mono">
+            {vulnerability.installedVersion || "-"}
+          </dd>
+        </div>
+        <div className="flex flex-col gap-1">
+          <dt className="text-muted-foreground">Faixa vulnerável</dt>
+          <dd className="break-all font-mono">
+            {vulnerability.vulnerableRange || "-"}
+          </dd>
+        </div>
+        <div className="flex flex-col gap-1">
+          <dt className="text-muted-foreground">Primeira versão corrigida</dt>
+          <dd className="break-all font-mono">
+            {vulnerability.firstPatchedVersion || "-"}
+          </dd>
+        </div>
+      </dl>
+
+      <div>
+        <div className="mb-2 text-xs font-medium text-muted-foreground">
+          Referências ({references.length})
+        </div>
+        {references.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {references.map((reference, index) => (
+              <Button
+                key={reference}
+                variant="outline"
+                size="xs"
+                render={<a href={reference} target="_blank" rel="noreferrer" />}
+                nativeButton={false}
+              >
+                {referenceLabel(reference)}
+                {references.length > 1 ? ` ${index + 1}` : ""}
+                <ExternalLinkIcon data-icon="inline-end" />
+              </Button>
+            ))}
+          </div>
+        ) : (
+          <span className="text-xs text-muted-foreground">
+            Nenhuma referência informada.
+          </span>
+        )}
+      </div>
+    </article>
+  )
+}
+
+function PackageOrigin({ group }: { group: PackageVulnerabilityGroup }) {
+  const origin = [
+    group.sourcePackages.length > 0
+      ? `source: ${group.sourcePackages.join(", ")}`
+      : "",
+    ...group.ecosystems,
+  ]
+    .filter(Boolean)
+    .join(" · ")
+
+  return origin ? (
+    <span className="block max-w-72 truncate text-xs font-normal text-muted-foreground">
+      {origin}
+    </span>
+  ) : null
+}
+
+function FixCoverage({ group }: { group: PackageVulnerabilityGroup }) {
+  if (group.fixableCount === 0) {
+    return <Badge variant="outline">Não publicado</Badge>
+  }
+
+  return (
+    <Badge variant="secondary">
+      {group.fixableCount}/{group.vulnerabilities.length} com fix
+    </Badge>
+  )
+}
+
+function PackageMetric({
+  label,
+  value,
+}: {
+  label: string
+  value: React.ReactNode
+}) {
+  return (
+    <div className="flex min-w-0 flex-col gap-1 border-r p-4 last:border-r-0 sm:p-5">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className="truncate font-medium">{value}</span>
+    </div>
+  )
+}
+
+function formatValues(values: string[]) {
+  return values.length > 0 ? values.join(", ") : "-"
+}
+
+function fallbackCopy(value: string) {
+  const textarea = document.createElement("textarea")
+  textarea.value = value
+  textarea.setAttribute("readonly", "")
+  textarea.style.position = "fixed"
+  textarea.style.opacity = "0"
+  document.body.appendChild(textarea)
+  textarea.select()
+  const copied = document.execCommand("copy")
+  textarea.remove()
+  if (!copied) {
+    throw new Error("Copy command was rejected")
+  }
+}

--- a/frontend/src/components/runtz/sca-components.tsx
+++ b/frontend/src/components/runtz/sca-components.tsx
@@ -32,6 +32,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { Skeleton } from "@/components/ui/skeleton"
 import {
   Tooltip,
   TooltipContent,
@@ -944,6 +945,43 @@ export function CVETable({
         ))}
       </TableBody>
     </Table>
+  )
+}
+
+export function ScanDetailSkeleton() {
+  return (
+    <div
+      className="flex flex-col gap-3"
+      role="status"
+      aria-label="Carregando detalhes do scan"
+    >
+      <span className="sr-only">Carregando detalhes do scan</span>
+      {Array.from({ length: 5 }).map((_, index) => (
+        <div
+          key={index}
+          className="grid items-center gap-3 border-b pb-3 last:border-b-0 md:grid-cols-[1.2fr_0.35fr_0.55fr_0.8fr]"
+        >
+          <Skeleton className="h-5 w-3/4" />
+          <Skeleton className="h-5 w-12" />
+          <Skeleton className="h-5 w-24" />
+          <Skeleton className="h-5 w-full" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function ScanDetailError({ message }: { message: string }) {
+  return (
+    <Empty className="min-h-48 border" role="alert">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <ShieldAlertIcon />
+        </EmptyMedia>
+        <EmptyTitle>Não foi possível carregar os detalhes</EmptyTitle>
+        <EmptyDescription>{message}</EmptyDescription>
+      </EmptyHeader>
+    </Empty>
   )
 }
 

--- a/frontend/src/components/runtz/use-scan-detail.ts
+++ b/frontend/src/components/runtz/use-scan-detail.ts
@@ -1,0 +1,73 @@
+"use client"
+
+import * as React from "react"
+
+import { usePlatform } from "@/components/runtz/platform-context"
+import {
+  apiRequest,
+  type FindingsScan,
+  type PackageScan,
+  type SCAScan,
+} from "@/lib/api"
+
+type Scan = SCAScan | FindingsScan | PackageScan
+
+export function useScanDetail<TScan extends Scan>(
+  scanType: TScan["type"],
+  scanSummary?: TScan
+) {
+  const { isPlayground } = usePlatform()
+  const [scan, setScan] = React.useState<TScan>()
+  const [loading, setLoading] = React.useState(false)
+  const [error, setError] = React.useState("")
+
+  React.useEffect(() => {
+    if (!scanSummary) {
+      setScan(undefined)
+      setLoading(false)
+      setError("")
+      return
+    }
+
+    if (isPlayground) {
+      setScan(scanSummary)
+      setLoading(false)
+      setError("")
+      return
+    }
+
+    let active = true
+    setScan(undefined)
+    setLoading(true)
+    setError("")
+
+    apiRequest<{ scan: TScan }>(
+      `/api/v1/scans/${scanType}/${encodeURIComponent(scanSummary.id)}?view=results`
+    )
+      .then((response) => {
+        if (active) {
+          setScan(response.scan)
+        }
+      })
+      .catch((requestError) => {
+        if (active) {
+          setError(
+            requestError instanceof Error
+              ? requestError.message
+              : "Falha ao carregar os detalhes do scan"
+          )
+        }
+      })
+      .finally(() => {
+        if (active) {
+          setLoading(false)
+        }
+      })
+
+    return () => {
+      active = false
+    }
+  }, [isPlayground, scanSummary, scanType])
+
+  return { scan, loading, error }
+}

--- a/frontend/src/lib/package-vulnerabilities.ts
+++ b/frontend/src/lib/package-vulnerabilities.ts
@@ -1,0 +1,234 @@
+import type { Vulnerability } from "@/lib/api"
+import type { SeverityKey } from "@/lib/sca"
+
+const SEVERITY_WEIGHT: Record<SeverityKey, number> = {
+  critical: 5,
+  high: 4,
+  medium: 3,
+  low: 2,
+  unknown: 1,
+}
+
+export type PackageVulnerabilityGroup = {
+  key: string
+  name: string
+  sourcePackages: string[]
+  ecosystems: string[]
+  installedVersions: string[]
+  highestSeverity: SeverityKey
+  fixableCount: number
+  vulnerabilities: Vulnerability[]
+}
+
+export type RemediationContext = {
+  targetName?: string
+  targetKind?: "host" | "container" | "application"
+  osName?: string
+  osVersion?: string
+  packageManager?: string
+}
+
+export function groupVulnerabilitiesByPackage(
+  vulnerabilities: Vulnerability[]
+): PackageVulnerabilityGroup[] {
+  const groups = new Map<string, Vulnerability[]>()
+
+  for (const vulnerability of vulnerabilities) {
+    const name = vulnerabilityPackageName(vulnerability)
+    const key = name.toLocaleLowerCase()
+    const current = groups.get(key) ?? []
+    current.push(vulnerability)
+    groups.set(key, current)
+  }
+
+  return Array.from(groups.entries())
+    .map(([key, packageVulnerabilities]) => {
+      const deduplicated = deduplicateVulnerabilities(packageVulnerabilities)
+      const highestSeverity = deduplicated.reduce<SeverityKey>(
+        (highest, vulnerability) =>
+          severityWeight(vulnerability.severity) > severityWeight(highest)
+            ? normalizeSeverity(vulnerability.severity)
+            : highest,
+        "unknown"
+      )
+
+      return {
+        key,
+        name: vulnerabilityPackageName(deduplicated[0]),
+        sourcePackages: uniqueValues(
+          packageVulnerabilities.map(
+            (vulnerability) => vulnerability.sourcePackage
+          )
+        ),
+        ecosystems: uniqueValues(
+          packageVulnerabilities.map(
+            (vulnerability) => vulnerability.ecosystem
+          )
+        ),
+        installedVersions: uniqueValues(
+          packageVulnerabilities.map(
+            (vulnerability) => vulnerability.installedVersion
+          )
+        ),
+        highestSeverity,
+        fixableCount: deduplicated.filter((vulnerability) =>
+          Boolean(vulnerability.firstPatchedVersion?.trim())
+        ).length,
+        vulnerabilities: deduplicated.sort(compareVulnerabilities),
+      }
+    })
+    .sort((left, right) => {
+      const severityDifference =
+        severityWeight(right.highestSeverity) -
+        severityWeight(left.highestSeverity)
+      return severityDifference || left.name.localeCompare(right.name)
+    })
+}
+
+export function vulnerabilityReferences(vulnerability: Vulnerability) {
+  return uniqueValues([
+    vulnerability.advisoryUrl,
+    ...(vulnerability.references ?? []),
+  ]).filter(isSafeExternalURL)
+}
+
+export function buildRemediationPrompt(
+  group: PackageVulnerabilityGroup,
+  context: RemediationContext = {}
+) {
+  const target = [context.targetKind, context.targetName]
+    .filter(Boolean)
+    .join(": ")
+  const operatingSystem = [context.osName, context.osVersion]
+    .filter(Boolean)
+    .join(" ")
+  const vulnerabilityLines = group.vulnerabilities
+    .map((vulnerability) => {
+      const references = vulnerabilityReferences(vulnerability)
+      return [
+        `- ${vulnerability.id} (${normalizeSeverity(vulnerability.severity)})`,
+        `  Installed: ${vulnerability.installedVersion || "unknown"}`,
+        `  Affected range: ${vulnerability.vulnerableRange || "not provided"}`,
+        `  First patched version: ${vulnerability.firstPatchedVersion || "not published"}`,
+        `  Summary: ${vulnerability.summary || "not provided"}`,
+        `  References: ${references.length > 0 ? references.join(", ") : "not provided"}`,
+      ].join("\n")
+    })
+    .join("\n")
+
+  return `You are a senior security and platform engineer. Create a safe, minimal, production-ready remediation plan for the vulnerable package below.
+
+Context
+- Target: ${target || "not provided"}
+- Operating system: ${operatingSystem || "not provided"}
+- Package manager: ${context.packageManager || "not provided"}
+- Package: ${group.name}
+- Source package: ${group.sourcePackages.join(", ") || "not provided"}
+- Ecosystem: ${group.ecosystems.join(", ") || "not provided"}
+- Installed version(s): ${group.installedVersions.join(", ") || "unknown"}
+
+Vulnerabilities
+${vulnerabilityLines}
+
+Requirements
+1. Verify whether every vulnerability is applicable to this exact package, version and environment. State any assumption.
+2. Recommend the smallest safe upgrade that remediates the maximum number of CVEs. Never invent a fixed version.
+3. If no patched version exists, propose concrete compensating controls and how to validate them.
+4. Provide exact commands or manifest/file changes appropriate to the package manager, but do not execute them.
+5. Identify likely breaking changes, service restart requirements and operational risks.
+6. Provide verification steps: package version check, focused regression tests and a vulnerability rescan.
+7. Include a rollback plan and call out CVEs that remain unresolved.
+
+Return: applicability assessment, recommended change, implementation steps, validation, rollback and residual risk.`
+}
+
+export function referenceLabel(reference: string) {
+  try {
+    const url = new URL(reference)
+    const hostname = url.hostname.replace(/^www\./, "")
+    if (url.pathname === "/") {
+      return hostname
+    }
+    const path =
+      url.pathname.length > 28
+        ? `${url.pathname.slice(0, 27)}…`
+        : url.pathname
+    return `${hostname}${path}`
+  } catch {
+    return reference
+  }
+}
+
+function vulnerabilityPackageName(vulnerability: Vulnerability) {
+  return (
+    vulnerability.installedPackage?.trim() ||
+    vulnerability.packageName?.trim() ||
+    "unknown"
+  )
+}
+
+function deduplicateVulnerabilities(vulnerabilities: Vulnerability[]) {
+  const unique = new Map<string, Vulnerability>()
+
+  for (const vulnerability of vulnerabilities) {
+    const key =
+      vulnerability.id?.trim().toLocaleLowerCase() ||
+      `${vulnerability.packageName}:${vulnerability.summary}`
+    const current = unique.get(key)
+
+    if (!current) {
+      unique.set(key, vulnerability)
+      continue
+    }
+
+    const currentReferences = vulnerabilityReferences(current)
+    const nextReferences = vulnerabilityReferences(vulnerability)
+    const higherSeverity =
+      severityWeight(vulnerability.severity) > severityWeight(current.severity)
+        ? vulnerability.severity
+        : current.severity
+
+    unique.set(key, {
+      ...current,
+      severity: higherSeverity,
+      firstPatchedVersion:
+        current.firstPatchedVersion || vulnerability.firstPatchedVersion,
+      advisoryUrl: current.advisoryUrl || vulnerability.advisoryUrl,
+      references: uniqueValues([...currentReferences, ...nextReferences]),
+    })
+  }
+
+  return Array.from(unique.values())
+}
+
+function compareVulnerabilities(left: Vulnerability, right: Vulnerability) {
+  const severityDifference =
+    severityWeight(right.severity) - severityWeight(left.severity)
+  return severityDifference || left.id.localeCompare(right.id)
+}
+
+function normalizeSeverity(severity: string): SeverityKey {
+  const normalized = severity?.trim().toLocaleLowerCase()
+  return normalized in SEVERITY_WEIGHT
+    ? (normalized as SeverityKey)
+    : "unknown"
+}
+
+function severityWeight(severity: string) {
+  return SEVERITY_WEIGHT[normalizeSeverity(severity)]
+}
+
+function uniqueValues(values: Array<string | undefined>) {
+  return Array.from(
+    new Set(values.map((value) => value?.trim()).filter(Boolean) as string[])
+  )
+}
+
+function isSafeExternalURL(value: string) {
+  try {
+    const url = new URL(value)
+    return url.protocol === "https:" || url.protocol === "http:"
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Groups repeated CVEs by installed package and opens a responsive package-detail sheet with consolidated vulnerability data, all safe external references, fix coverage, and a copyable AI remediation prompt.

The scan API now returns lightweight metadata for collection views, adds result-only detail loading, and creates compound indexes for type/workspace/date queries. Detail screens progressively fetch only the result array they need, reducing payload and initial rendering work across SCA, SAST, host, container, and Kubernetes views.

A synthetic validation with 5,000 packages and 5,000 CVEs reduced a multi-scan listing response to approximately 18 KB while preserving the complete detail endpoint.

## Base branch

- [x] This PR targets `dev` (or is a release promotion to `main`)

## Checklist

- [x] `cd engine && go test ./...` passes
- [x] `cd frontend && npm run lint && npm run build` passes (if frontend changed)
- [x] Helm chart unchanged; `helm lint` is not applicable
- [x] No secrets, tokens or personal endpoints in the diff
- [x] Docs updated (README / site docs) if behavior changed

## Generated by

- **Author:** Codex (GPT-5)
- **Task / prompt:** Group repeated package CVEs into a new detail experience and resolve slow scan dashboard loading.
- **How it was verified:** `go test ./...`, `go vet ./...`, `npm run lint`, `npm run build`, synthetic API payload measurement, and desktop/mobile browser inspection at 1440px and 375px.
- [ ] A human reviewed the full diff and takes responsibility for it

By submitting this pull request, I agree that my contribution is provided
under the project license (BUSL-1.1) as described in CONTRIBUTING.md.
