### PR TITLE
Store empty arrays instead of null on scan ingest

### DIFF
--- a/engine/internal/api/server.go
+++ b/engine/internal/api/server.go
@@ -830,8 +830,8 @@ func (s *Server) handleIngestSCA(w http.ResponseWriter, r *http.Request) {
 		Status:          "completed",
 		ScannerVersion:  request.ScannerVersion,
 		Summary:         buildSummary(request.Dependencies, request.Vulnerabilities),
-		Dependencies:    request.Dependencies,
-		Vulnerabilities: request.Vulnerabilities,
+		Dependencies:    orEmpty(request.Dependencies),
+		Vulnerabilities: orEmpty(request.Vulnerabilities),
 		CreatedAt:       now,
 	}
 
@@ -996,7 +996,7 @@ func (s *Server) handleIngestPackageScan(w http.ResponseWriter, r *http.Request,
 		ScannerVersion:  request.ScannerVersion,
 		Summary:         buildPackageSummary(request.Packages, request.Vulnerabilities),
 		Packages:        request.Packages,
-		Vulnerabilities: request.Vulnerabilities,
+		Vulnerabilities: orEmpty(request.Vulnerabilities),
 		CreatedAt:       now,
 	}
 
@@ -1271,6 +1271,18 @@ func buildFindingSummary(totalScanned int, findings []Finding) ScanSummary {
 	}
 
 	return summary
+}
+
+// orEmpty turns a nil slice into an empty one so it is stored — and later
+// served — as [] instead of null. Scanners legitimately send no results at
+// all: macOS host scans never carry vulnerabilities because OSV has no feed
+// for Homebrew, and Go marshals a nil slice as null. Clients then have to
+// guard every read, and the one that forgets crashes on .length.
+func orEmpty[T any](values []T) []T {
+	if values == nil {
+		return []T{}
+	}
+	return values
 }
 
 func firstNonEmpty(values ...string) string {

--- a/frontend/src/components/runtz/sca-components.tsx
+++ b/frontend/src/components/runtz/sca-components.tsx
@@ -4,7 +4,6 @@ import * as React from "react"
 import {
   ActivityIcon,
   ChartSplineIcon,
-  ExternalLinkIcon,
   PackageIcon,
   ShieldAlertIcon,
 } from "lucide-react"
@@ -24,14 +23,6 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@/components/ui/empty"
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
   Tooltip,
@@ -39,7 +30,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
-import type { ScanSummary, Vulnerability } from "@/lib/api"
+import type { ScanSummary } from "@/lib/api"
 import type { TrendScan } from "@/lib/dashboard"
 import {
   countSeverity,
@@ -866,85 +857,6 @@ export function SeverityBadge({ severity }: { severity: string }) {
     <Badge variant="outline" className={meta.badgeClassName}>
       {severity || "unknown"}
     </Badge>
-  )
-}
-
-export function CVETable({
-  vulnerabilities,
-}: {
-  vulnerabilities: Vulnerability[]
-}) {
-  if (vulnerabilities.length === 0) {
-    return (
-      <Empty className="min-h-48 border">
-        <EmptyHeader>
-          <EmptyMedia variant="icon">
-            <ShieldAlertIcon />
-          </EmptyMedia>
-          <EmptyTitle>No vulnerabilities found</EmptyTitle>
-          <EmptyDescription>
-            The latest scan returned no advisories for the identified versions.
-          </EmptyDescription>
-        </EmptyHeader>
-      </Empty>
-    )
-  }
-
-  return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead>Pacote</TableHead>
-          <TableHead>ID</TableHead>
-          <TableHead>Severidade</TableHead>
-          <TableHead>Version</TableHead>
-          <TableHead>Fix</TableHead>
-          <TableHead>Resumo</TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {vulnerabilities.map((vulnerability) => (
-          <TableRow key={`${vulnerability.packageName}-${vulnerability.id}`}>
-            <TableCell className="font-medium">
-              <div className="flex min-w-40 flex-col gap-1">
-                <span>
-                  {vulnerability.installedPackage || vulnerability.packageName}
-                </span>
-                {vulnerability.sourcePackage &&
-                vulnerability.sourcePackage !== vulnerability.installedPackage ? (
-                  <span className="text-xs font-normal text-muted-foreground">
-                    source: {vulnerability.sourcePackage}
-                  </span>
-                ) : null}
-              </div>
-            </TableCell>
-            <TableCell>
-              {vulnerability.advisoryUrl ? (
-                <a
-                  className="inline-flex items-center gap-1 text-primary underline-offset-4 hover:underline"
-                  href={vulnerability.advisoryUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  {vulnerability.id}
-                  <ExternalLinkIcon />
-                </a>
-              ) : (
-                vulnerability.id
-              )}
-            </TableCell>
-            <TableCell>
-              <SeverityBadge severity={vulnerability.severity} />
-            </TableCell>
-            <TableCell>{vulnerability.installedVersion || "-"}</TableCell>
-            <TableCell>{vulnerability.firstPatchedVersion || "-"}</TableCell>
-            <TableCell className="min-w-72 whitespace-normal">
-              {vulnerability.summary}
-            </TableCell>
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>
   )
 }
 


### PR DESCRIPTION
## What does this PR do?

A macOS host scan sent `"vulnerabilities": null` — OSV has no advisory feed for Homebrew, so the CLI never fills the slice and Go marshals nil as null. The engine passed it straight through to Mongo, and the host detail page crashed on `vulnerabilities.length`, rendering *"This page couldn't load"* instead of the host.

The crash itself was already fixed by accident in d183588 (v1.0.0-rc7), which replaced `CVETable` with `PackageVulnerabilityExplorer` and its `?? []` guard. This PR fixes the cause rather than the symptom: the engine now stores `[]`, so no client has to remember to guard.

Verified against the reported document (macOS 26.5.2, brew, 28 packages, `vulnerabilities: null`):

```
before: vulnerabilities served as null
after:  vulnerabilities served as []
```

Scope note: `orEmpty` is applied to `dependencies` and `vulnerabilities` only. `packages` and `findings` are tagged `bson:",omitempty"`, so an empty slice is dropped from the document anyway — absent and empty are indistinguishable there by design, and the list projection relies on it. Applying it there would look like a fix without being one.

Also removes `CVETable` — the component that crashed, left exported but unused since d183588.

Not included: a regression test pinning this behavior, and a backfill for documents already stored with `null` (they render today thanks to the `?? []` guards).

## Base branch

- [x] This PR targets `dev` (or is a release promotion to `main`)

## Checklist

- [x] `cd engine && go test ./...` passes
- [x] `cd frontend && npm run lint && npm run build` passes (if frontend changed)
- [ ] `helm lint helm/runtz` passes (if chart changed) — chart untouched
- [x] No secrets, tokens or personal endpoints in the diff
- [ ] Docs updated (README / site docs) if behavior changed — no user-facing behavior change

## Generated by

- **Author:** Claude (claude-opus-5)
- **Task / prompt:** Investigate a host scan from a Mac whose `.local` hostname appeared to break the site, then propose and implement the fix.
- **How it was verified:** Ruled out the URL dot by serving `/app/hosts/<name>.local` on dev, production build and RSC navigation (200 in all three). Rebuilt v1.0.0-rc5 — what production ran the day of the report — and reproduced the crash in Chrome: the Linux host rendered, the macOS host threw `Cannot read properties of null (reading 'length')` and showed the error page. Confirmed the BSON round-trip (`nil → null`, `orEmpty → []`, and that `orEmpty` is inert under `omitempty`) with a throwaway Go test, then confirmed the current build renders the reported document cleanly. `go vet`, `go test`, `npm run lint`, `npm run build` all pass.
- [ ] A human reviewed the full diff and takes responsibility for it

By submitting this pull request, I agree that my contribution is provided
under the project license (BUSL-1.1) as described in CONTRIBUTING.md.