### PR TITLE
Add scan limits and improve API key management

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ follow `1.0.0-rc1 → 1.0.0-rc2 → ... → 1.0.0`, then regular semver
 - `POST /api/v1/workspaces`
 - `GET /api/v1/api-keys`
 - `POST /api/v1/api-keys`
-- `PATCH /api/v1/api-keys/{id}/revoke`
+- `PATCH /api/v1/api-keys/{id}`
+- `DELETE /api/v1/api-keys/{id}`
 - `POST /api/v1/billing/checkout`
 - `POST /api/v1/billing/portal`
 - `GET /api/v1/billing/status`
@@ -222,6 +223,16 @@ Terraform):
   published.
 
 ### Paid plans and fair use
+
+Scan ingestion uses rolling limits per workspace:
+
+| Plan | Weekly (7 days) | Monthly (30 days) |
+| --- | ---: | ---: |
+| Free | 2,500 | 10,000 |
+| Pro and Enterprise | 1,000,000 | 1,000,000 |
+
+The paid weekly allowance intentionally matches the monthly allowance, so a
+paying workspace may use its entire monthly capacity within one week.
 
 Pro and Enterprise are gated by a cryptographic license: the central engine at
 `https://engine.runtz.dev` signs short-lived certificates that every runtz

--- a/engine/internal/api/api_keys.go
+++ b/engine/internal/api/api_keys.go
@@ -92,6 +92,10 @@ func (s *Server) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "workspace not found")
 		return
 	}
+	if workspace.Kind == "playground" {
+		writeError(w, http.StatusBadRequest, "playground workspace cannot issue api keys")
+		return
+	}
 
 	rawKey, prefix, err := generateAPIKey()
 	if err != nil {
@@ -122,6 +126,85 @@ func (s *Server) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 		"apiKey": serializeAPIKey(apiKey),
 		"key":    rawKey,
 	})
+}
+
+func (s *Server) handleUpdateAPIKey(w http.ResponseWriter, r *http.Request) {
+	user, _ := currentUser(r.Context())
+	apiKeyID, err := bson.ObjectIDFromHex(r.PathValue("id"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid api key id")
+		return
+	}
+	var request struct {
+		Name string `json:"name"`
+	}
+	if !decodeJSON(w, r, &request) {
+		return
+	}
+
+	name := strings.TrimSpace(request.Name)
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if len(name) > 80 {
+		writeError(w, http.StatusBadRequest, "name must be 80 characters or fewer")
+		return
+	}
+
+	var apiKey APIKey
+	if err := s.apiKeys.FindOne(r.Context(), bson.M{"_id": apiKeyID}).Decode(&apiKey); err != nil {
+		writeError(w, http.StatusNotFound, "api key not found")
+		return
+	}
+	if !s.userCanAccessWorkspace(user, apiKey.WorkspaceID) {
+		writeError(w, http.StatusForbidden, "workspace access required")
+		return
+	}
+
+	result := s.apiKeys.FindOneAndUpdate(
+		r.Context(),
+		bson.M{"_id": apiKey.ID},
+		bson.M{"$set": bson.M{"name": name, "updated_at": time.Now().UTC()}},
+		options.FindOneAndUpdate().SetReturnDocument(options.After),
+	)
+	if err := result.Decode(&apiKey); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to update api key")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"apiKey": serializeAPIKey(apiKey)})
+}
+
+func (s *Server) handleDeleteAPIKey(w http.ResponseWriter, r *http.Request) {
+	user, _ := currentUser(r.Context())
+	apiKeyID, err := bson.ObjectIDFromHex(r.PathValue("id"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid api key id")
+		return
+	}
+
+	var apiKey APIKey
+	if err := s.apiKeys.FindOne(r.Context(), bson.M{"_id": apiKeyID}).Decode(&apiKey); err != nil {
+		writeError(w, http.StatusNotFound, "api key not found")
+		return
+	}
+	if !s.userCanAccessWorkspace(user, apiKey.WorkspaceID) {
+		writeError(w, http.StatusForbidden, "workspace access required")
+		return
+	}
+
+	result, err := s.apiKeys.DeleteOne(r.Context(), bson.M{"_id": apiKey.ID})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to delete api key")
+		return
+	}
+	if result.DeletedCount == 0 {
+		writeError(w, http.StatusNotFound, "api key not found")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *Server) handleRevokeAPIKey(w http.ResponseWriter, r *http.Request) {
@@ -170,6 +253,15 @@ func (s *Server) authenticateIngest(w http.ResponseWriter, r *http.Request) (Wor
 	workspace, err := s.workspaceFromAPIKey(r.Context(), apiKeyValue)
 	if err != nil {
 		writeError(w, http.StatusUnauthorized, "invalid api key")
+		return Workspace{}, false
+	}
+	if err := s.enforceScanUsageLimit(r.Context(), workspace.ID, workspace.CreatedBy); err != nil {
+		var limitError *usageLimitError
+		if errors.As(err, &limitError) {
+			writeError(w, http.StatusTooManyRequests, limitError.Error())
+			return Workspace{}, false
+		}
+		writeError(w, http.StatusInternalServerError, "failed to check scan usage")
 		return Workspace{}, false
 	}
 

--- a/engine/internal/api/plans.go
+++ b/engine/internal/api/plans.go
@@ -16,6 +16,11 @@ const (
 	planPro        = "pro"
 	planEnterprise = "enterprise"
 
+	freeWeeklyScanLimit  int64 = 2_500
+	freeMonthlyScanLimit int64 = 10_000
+	paidWeeklyScanLimit  int64 = 1_000_000
+	paidMonthlyScanLimit int64 = 1_000_000
+
 	hostingCloud      = "cloud"
 	hostingSelfHosted = "self-hosted"
 
@@ -27,6 +32,11 @@ const (
 
 	instanceStateKey = "default"
 )
+
+type scanUsageLimits struct {
+	Weekly  int64 `json:"weekly"`
+	Monthly int64 `json:"monthly"`
+}
 
 type Entitlement struct {
 	Plan              string   `json:"plan"`
@@ -102,6 +112,20 @@ func planRank(plan string) int {
 		return 2
 	default:
 		return 1
+	}
+}
+
+func usageLimitsForPlan(plan string) scanUsageLimits {
+	if planRank(plan) >= planRank(planPro) {
+		return scanUsageLimits{
+			Weekly:  paidWeeklyScanLimit,
+			Monthly: paidMonthlyScanLimit,
+		}
+	}
+
+	return scanUsageLimits{
+		Weekly:  freeWeeklyScanLimit,
+		Monthly: freeMonthlyScanLimit,
 	}
 }
 

--- a/engine/internal/api/server.go
+++ b/engine/internal/api/server.go
@@ -103,6 +103,8 @@ func (s *Server) Handler() http.Handler {
 	mux.Handle("POST /api/v1/workspaces", s.adminOnly(http.HandlerFunc(s.handleCreateWorkspace)))
 	mux.Handle("GET /api/v1/api-keys", s.auth(http.HandlerFunc(s.handleListAPIKeys)))
 	mux.Handle("POST /api/v1/api-keys", s.auth(http.HandlerFunc(s.handleCreateAPIKey)))
+	mux.Handle("PATCH /api/v1/api-keys/{id}", s.auth(http.HandlerFunc(s.handleUpdateAPIKey)))
+	mux.Handle("DELETE /api/v1/api-keys/{id}", s.auth(http.HandlerFunc(s.handleDeleteAPIKey)))
 	mux.Handle("PATCH /api/v1/api-keys/{id}/revoke", s.auth(http.HandlerFunc(s.handleRevokeAPIKey)))
 	mux.HandleFunc("POST /api/v1/billing/checkout", s.handleCreateCheckoutSession)
 	mux.Handle("POST /api/v1/billing/portal", s.auth(http.HandlerFunc(s.handleCreateBillingPortalSession)))
@@ -285,7 +287,7 @@ func (s *Server) withCORS(next http.Handler) http.Handler {
 			w.Header().Set("Vary", "Origin")
 			w.Header().Set("Access-Control-Allow-Credentials", "true")
 			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Runtz-API-Key")
-			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PATCH, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
 		}
 
 		if r.Method == http.MethodOptions {

--- a/engine/internal/api/usage.go
+++ b/engine/internal/api/usage.go
@@ -2,10 +2,13 @@ package api
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
 // Rolling windows used by the Usage panel in the platform settings. They are
@@ -25,8 +28,22 @@ type usageWindow struct {
 	Since  string           `json:"since"`
 }
 
+type usageLimitError struct {
+	Window string
+	Limit  int64
+}
+
+func (e *usageLimitError) Error() string {
+	return fmt.Sprintf(
+		"%s scan limit reached (%s); upgrade your plan or wait for older scans to leave the usage window",
+		e.Window,
+		formatUsageLimit(e.Limit),
+	)
+}
+
 func (s *Server) handleUsage(w http.ResponseWriter, r *http.Request) {
 	user, _ := currentUser(r.Context())
+	plan := s.currentEntitlement(r.Context(), &user).Plan
 
 	filter := bson.M{}
 	if workspaceIDParam := r.URL.Query().Get("workspaceId"); workspaceIDParam != "" {
@@ -39,9 +56,26 @@ func (s *Server) handleUsage(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusForbidden, "workspace access required")
 			return
 		}
+		var workspace Workspace
+		if err := s.workspaces.FindOne(r.Context(), bson.M{"_id": workspaceID}).Decode(&workspace); err != nil {
+			writeError(w, http.StatusNotFound, "workspace not found")
+			return
+		}
+		plan, err = s.planForWorkspace(r.Context(), workspace.CreatedBy)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to load workspace plan")
+			return
+		}
 		filter["workspace_id"] = workspaceID
 	} else if !s.globalDataScope(user) {
 		filter["workspace_id"] = bson.M{"$in": user.WorkspaceIDs}
+	} else {
+		// Playground data is generated for the public demo and is never an
+		// ingested scan, so it must not consume an installation's allowance.
+		var playground Workspace
+		if err := s.workspaces.FindOne(r.Context(), bson.M{"slug": playgroundWorkspaceSlug}).Decode(&playground); err == nil {
+			filter["workspace_id"] = bson.M{"$ne": playground.ID}
+		}
 	}
 
 	now := time.Now().UTC()
@@ -54,9 +88,70 @@ func (s *Server) handleUsage(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
 		"weekly":      weekly,
 		"monthly":     monthly,
+		"limits":      usageLimitsForPlan(plan),
+		"plan":        plan,
 		"scanTypes":   usageScanTypes,
 		"generatedAt": now.Format(time.RFC3339),
 	})
+}
+
+// enforceScanUsageLimit applies the plan allowance to the workspace resolved
+// from the API key. Keeping the check workspace-scoped makes it match the
+// counters users see after selecting that workspace in Settings > Usage.
+func (s *Server) enforceScanUsageLimit(ctx context.Context, workspaceID, workspaceOwnerID bson.ObjectID) error {
+	plan, err := s.planForWorkspace(ctx, workspaceOwnerID)
+	if err != nil {
+		return err
+	}
+
+	weekly, monthly, err := s.countScansInWindows(ctx, bson.M{"workspace_id": workspaceID}, time.Now().UTC())
+	if err != nil {
+		return err
+	}
+
+	return scanUsageLimitError(weekly.Total, monthly.Total, usageLimitsForPlan(plan))
+}
+
+func (s *Server) planForWorkspace(ctx context.Context, workspaceOwnerID bson.ObjectID) (string, error) {
+	if s.cfg.DeploymentMode == hostingSelfHosted {
+		return s.currentEntitlement(ctx, nil).Plan, nil
+	}
+	if workspaceOwnerID.IsZero() {
+		return planFree, nil
+	}
+
+	var user User
+	if err := s.users.FindOne(ctx, bson.M{"_id": workspaceOwnerID}).Decode(&user); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return planFree, nil
+		}
+		return "", err
+	}
+
+	return s.currentEntitlement(ctx, &user).Plan, nil
+}
+
+func scanUsageLimitError(weekly, monthly int64, limits scanUsageLimits) error {
+	if weekly >= limits.Weekly {
+		return &usageLimitError{Window: "weekly", Limit: limits.Weekly}
+	}
+	if monthly >= limits.Monthly {
+		return &usageLimitError{Window: "monthly", Limit: limits.Monthly}
+	}
+	return nil
+}
+
+func formatUsageLimit(limit int64) string {
+	switch limit {
+	case 1_000_000:
+		return "1,000,000"
+	case 10_000:
+		return "10,000"
+	case 2_500:
+		return "2,500"
+	default:
+		return fmt.Sprintf("%d", limit)
+	}
 }
 
 // countScansInWindows counts the scans matching filter in a single aggregation:

--- a/engine/internal/api/usage_test.go
+++ b/engine/internal/api/usage_test.go
@@ -33,3 +33,37 @@ func TestUsageWindowsAreRolling(t *testing.T) {
 		t.Fatal("the monthly window must be wider than the weekly one")
 	}
 }
+
+func TestUsageLimitsForPlan(t *testing.T) {
+	tests := []struct {
+		plan string
+		want scanUsageLimits
+	}{
+		{plan: planFree, want: scanUsageLimits{Weekly: 2_500, Monthly: 10_000}},
+		{plan: planPro, want: scanUsageLimits{Weekly: 1_000_000, Monthly: 1_000_000}},
+		{plan: planEnterprise, want: scanUsageLimits{Weekly: 1_000_000, Monthly: 1_000_000}},
+	}
+
+	for _, test := range tests {
+		if got := usageLimitsForPlan(test.plan); got != test.want {
+			t.Fatalf("usageLimitsForPlan(%q) = %+v, want %+v", test.plan, got, test.want)
+		}
+	}
+}
+
+func TestScanUsageLimitErrorAtBoundary(t *testing.T) {
+	limits := usageLimitsForPlan(planFree)
+	if err := scanUsageLimitError(limits.Weekly-1, limits.Monthly-1, limits); err != nil {
+		t.Fatalf("usage below both limits should be accepted: %v", err)
+	}
+
+	weeklyErr := scanUsageLimitError(limits.Weekly, limits.Monthly-1, limits)
+	if weeklyErr == nil || weeklyErr.Error() != "weekly scan limit reached (2,500); upgrade your plan or wait for older scans to leave the usage window" {
+		t.Fatalf("unexpected weekly limit error: %v", weeklyErr)
+	}
+
+	monthlyErr := scanUsageLimitError(0, limits.Monthly, limits)
+	if monthlyErr == nil || monthlyErr.Error() != "monthly scan limit reached (10,000); upgrade your plan or wait for older scans to leave the usage window" {
+		t.Fatalf("unexpected monthly limit error: %v", monthlyErr)
+	}
+}

--- a/frontend/src/app/app/api-keys/page.tsx
+++ b/frontend/src/app/app/api-keys/page.tsx
@@ -1,7 +1,19 @@
 "use client"
 
 import * as React from "react"
-import { CheckIcon, CopyIcon, PlusIcon, RefreshCcwIcon, XIcon } from "lucide-react"
+import {
+  CheckIcon,
+  CopyIcon,
+  KeyRoundIcon,
+  MoreHorizontalIcon,
+  PencilIcon,
+  PlusIcon,
+  RefreshCcwIcon,
+  SearchIcon,
+  ShieldCheckIcon,
+  Trash2Icon,
+  TriangleAlertIcon,
+} from "lucide-react"
 
 import { useWorkspace } from "@/components/runtz/workspace-context"
 import { Badge } from "@/components/ui/badge"
@@ -17,16 +29,25 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
 import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldGroup,
-  FieldLabel,
-} from "@/components/ui/field"
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty"
+import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import {
   Select,
@@ -55,37 +76,81 @@ export default function APIKeysPage() {
   const [name, setName] = React.useState("CLI key")
   const [newKey, setNewKey] = React.useState("")
   const [copied, setCopied] = React.useState(false)
+  const [query, setQuery] = React.useState("")
   const [error, setError] = React.useState("")
+  const [loading, setLoading] = React.useState(true)
   const [pending, setPending] = React.useState(false)
+  const [createOpen, setCreateOpen] = React.useState(false)
+  const [editingKey, setEditingKey] = React.useState<ApiKey | null>(null)
+  const [editingName, setEditingName] = React.useState("")
+  const [deletingKey, setDeletingKey] = React.useState<ApiKey | null>(null)
 
   const effectiveWorkspaceId =
     selectedWorkspaceId !== ALL_WORKSPACES ? selectedWorkspaceId : ""
+  const availableWorkspaces = React.useMemo(
+    () => workspaces.filter((workspace) => workspace.kind !== "playground"),
+    [workspaces]
+  )
 
   const loadAPIKeys = React.useCallback(async () => {
-
-    const query = effectiveWorkspaceId
-      ? `?workspaceId=${encodeURIComponent(effectiveWorkspaceId)}`
-      : ""
-    const response = await apiRequest<{ apiKeys: ApiKey[] }>(
-      `/api/v1/api-keys${query}`
-    )
-    setAPIKeys(response.apiKeys ?? [])
+    setLoading(true)
+    setError("")
+    try {
+      const workspaceQuery = effectiveWorkspaceId
+        ? `?workspaceId=${encodeURIComponent(effectiveWorkspaceId)}`
+        : ""
+      const response = await apiRequest<{ apiKeys: ApiKey[] }>(
+        `/api/v1/api-keys${workspaceQuery}`
+      )
+      setAPIKeys(response.apiKeys ?? [])
+    } catch (loadError) {
+      setError(
+        loadError instanceof Error ? loadError.message : "Failed to load API keys"
+      )
+    } finally {
+      setLoading(false)
+    }
   }, [effectiveWorkspaceId])
 
   React.useEffect(() => {
-    loadAPIKeys().catch(() => setAPIKeys([]))
+    loadAPIKeys()
   }, [loadAPIKeys])
 
   React.useEffect(() => {
-    if (workspaceId && workspaces.some((workspace) => workspace.id === workspaceId)) {
+    if (
+      workspaceId &&
+      availableWorkspaces.some((workspace) => workspace.id === workspaceId)
+    ) {
       return
     }
-    if (effectiveWorkspaceId) {
+    if (
+      effectiveWorkspaceId &&
+      availableWorkspaces.some((workspace) => workspace.id === effectiveWorkspaceId)
+    ) {
       setWorkspaceId(effectiveWorkspaceId)
       return
     }
-    setWorkspaceId(workspaces[0]?.id ?? "")
-  }, [effectiveWorkspaceId, workspaceId, workspaces])
+    setWorkspaceId(availableWorkspaces[0]?.id ?? "")
+  }, [availableWorkspaces, effectiveWorkspaceId, workspaceId])
+
+  const workspaceNameById = React.useMemo(
+    () => new Map(workspaces.map((workspace) => [workspace.id, workspace.name])),
+    [workspaces]
+  )
+
+  const filteredAPIKeys = React.useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase()
+    if (!normalizedQuery) {
+      return apiKeys
+    }
+
+    return apiKeys.filter((apiKey) => {
+      const workspaceName = workspaceNameById.get(apiKey.workspaceId) ?? ""
+      return [apiKey.name, apiKey.prefix, workspaceName].some((value) =>
+        value.toLowerCase().includes(normalizedQuery)
+      )
+    })
+  }, [apiKeys, query, workspaceNameById])
 
   async function createAPIKey(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -104,27 +169,74 @@ export default function APIKeysPage() {
         }
       )
       setAPIKeys((current) => [response.apiKey, ...current])
+      setCreateOpen(false)
       setNewKey(response.key)
       setName("CLI key")
       setCopied(false)
-    } catch (error) {
-      setError(error instanceof Error ? error.message : "Failed to create API key")
+    } catch (createError) {
+      setError(
+        createError instanceof Error
+          ? createError.message
+          : "Failed to create API key"
+      )
     } finally {
       setPending(false)
     }
   }
 
-  async function revokeAPIKey(apiKey: ApiKey) {
+  function openEditDialog(apiKey: ApiKey) {
+    setError("")
+    setEditingName(apiKey.name)
+    setEditingKey(apiKey)
+  }
+
+  async function updateAPIKey(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!editingKey || !editingName.trim()) {
+      return
+    }
 
     setError("")
     setPending(true)
     try {
-      await apiRequest(`/api/v1/api-keys/${apiKey.id}/revoke`, {
-        method: "PATCH",
+      const response = await apiRequest<{ apiKey: ApiKey }>(
+        `/api/v1/api-keys/${editingKey.id}`,
+        { method: "PATCH", body: { name: editingName.trim() } }
+      )
+      setAPIKeys((current) =>
+        current.map((apiKey) =>
+          apiKey.id === response.apiKey.id ? response.apiKey : apiKey
+        )
+      )
+      setEditingKey(null)
+    } catch (updateError) {
+      setError(
+        updateError instanceof Error ? updateError.message : "Failed to update API key"
+      )
+    } finally {
+      setPending(false)
+    }
+  }
+
+  async function deleteAPIKey() {
+    if (!deletingKey) {
+      return
+    }
+
+    setError("")
+    setPending(true)
+    try {
+      await apiRequest<void>(`/api/v1/api-keys/${deletingKey.id}`, {
+        method: "DELETE",
       })
-      await loadAPIKeys()
-    } catch (error) {
-      setError(error instanceof Error ? error.message : "Failed to revoke API key")
+      setAPIKeys((current) =>
+        current.filter((apiKey) => apiKey.id !== deletingKey.id)
+      )
+      setDeletingKey(null)
+    } catch (deleteError) {
+      setError(
+        deleteError instanceof Error ? deleteError.message : "Failed to delete API key"
+      )
     } finally {
       setPending(false)
     }
@@ -135,178 +247,452 @@ export default function APIKeysPage() {
     setCopied(true)
   }
 
-  const workspaceNameById = new Map(
-    workspaces.map((workspace) => [workspace.id, workspace.name])
-  )
-
   return (
     <div className="flex flex-col gap-6 p-4 md:p-6">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-normal">API Keys</h1>
-        <p className="text-sm text-muted-foreground">
-          Chaves para conectar o CLI ao workspace selecionado.
-        </p>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-normal">API keys</h1>
+          <p className="text-sm text-muted-foreground">
+            Create and manage keys used to send scans from the CLI.
+          </p>
+        </div>
+        <Button
+          size="lg"
+          className="w-full shadow-sm sm:w-auto"
+          onClick={() => {
+            setError("")
+            setCreateOpen(true)
+          }}
+        >
+          <PlusIcon data-icon="inline-start" />
+          Create API key
+        </Button>
       </div>
 
-      <div className="grid gap-6 xl:grid-cols-[380px_1fr]">
-        <Card>
-          <CardHeader>
-            <CardTitle>Nova API key</CardTitle>
-            <CardDescription>A chave completa aparece apenas uma vez.</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <form onSubmit={createAPIKey}>
-              <FieldGroup>
-                <Field>
-                  <FieldLabel htmlFor="api-key-name">Nome</FieldLabel>
-                  <Input
-                    id="api-key-name"
-                    value={name}
-                    onChange={(event) => setName(event.target.value)}
-                    required
-                  />
-                </Field>
-                <Field>
-                  <FieldLabel>Workspace</FieldLabel>
-                  <Select
-                    value={workspaceId}
-                    onValueChange={(value) => {
-                      if (value) {
-                        setWorkspaceId(value)
-                      }
-                    }}
-                  >
-                    <SelectTrigger className="w-full">
-                      <SelectValue placeholder="Workspace" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        {workspaces.map((workspace) => (
-                          <SelectItem key={workspace.id} value={workspace.id}>
-                            {workspace.name}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                  <FieldDescription>
-                    A API key sempre resolve o workspace por baixo dos panos.
-                  </FieldDescription>
-                </Field>
-                {error ? (
-                  <Field>
-                    <FieldError>{error}</FieldError>
-                  </Field>
-                ) : null}
-                <Button type="submit" disabled={pending || !workspaceId}>
-                  <PlusIcon data-icon="inline-start" />
-                  Gerar API key
-                </Button>
-              </FieldGroup>
-            </form>
-          </CardContent>
-        </Card>
+      {error && !createOpen && !editingKey && !deletingKey ? (
+        <p className="rounded-lg border border-destructive/25 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </p>
+      ) : null}
 
-        <Card>
-          <CardHeader>
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <CardTitle>API keys ativas</CardTitle>
-                <CardDescription>{apiKeys.length} cadastradas</CardDescription>
+      <Card className="overflow-hidden">
+        <CardHeader className="border-b bg-background/35">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <div className="flex items-center gap-2">
+                <CardTitle>Active keys</CardTitle>
+                <Badge variant="secondary">{apiKeys.length}</Badge>
+              </div>
+              <CardDescription className="mt-1">
+                Keys are scoped to one workspace and have scan sending access.
+              </CardDescription>
+            </div>
+            <div className="flex w-full gap-2 lg:max-w-md">
+              <div className="relative min-w-0 flex-1">
+                <SearchIcon className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  className="pl-8"
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="Search keys..."
+                  aria-label="Search API keys"
+                />
               </div>
               <Button
                 variant="outline"
-                size="sm"
-                onClick={() => loadAPIKeys()}
-                disabled={pending}
+                size="icon"
+                onClick={loadAPIKeys}
+                disabled={loading || pending}
+                aria-label="Refresh API keys"
               >
-                <RefreshCcwIcon data-icon="inline-start" />
-                Atualizar
+                <RefreshCcwIcon className={loading ? "animate-spin" : ""} />
               </Button>
             </div>
-          </CardHeader>
-          <CardContent>
-            <div className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Nome</TableHead>
-                    <TableHead>Workspace</TableHead>
-                    <TableHead>Prefixo</TableHead>
-                    <TableHead>Último uso</TableHead>
-                    <TableHead className="text-right">Actions</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {apiKeys.map((apiKey) => (
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          <div className="md:hidden">
+            {loading ? (
+              <p className="px-4 py-12 text-center text-sm text-muted-foreground">
+                Loading API keys...
+              </p>
+            ) : null}
+            {!loading && filteredAPIKeys.length === 0 ? (
+              <APIKeysEmptyState hasQuery={Boolean(query)} />
+            ) : null}
+            {!loading
+              ? filteredAPIKeys.map((apiKey) => (
+                  <div key={apiKey.id} className="grid gap-3 border-b p-4 last:border-b-0">
+                    <div className="flex min-w-0 items-start gap-3">
+                      <div className="flex size-9 shrink-0 items-center justify-center rounded-lg border bg-primary/10 text-primary">
+                        <KeyRoundIcon className="size-4" />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium">{apiKey.name}</p>
+                        <p className="truncate text-xs text-muted-foreground">
+                          {workspaceNameById.get(apiKey.workspaceId) ?? apiKey.workspaceId}
+                        </p>
+                      </div>
+                      <APIKeyActions
+                        apiKey={apiKey}
+                        onEdit={openEditDialog}
+                        onDelete={(key) => {
+                          setError("")
+                          setDeletingKey(key)
+                        }}
+                      />
+                    </div>
+                    <div className="grid grid-cols-2 gap-3 text-xs">
+                      <div className="min-w-0">
+                        <p className="mb-1 text-muted-foreground">Token</p>
+                        <code className="block truncate rounded-md bg-muted px-2 py-1 font-mono">
+                          {apiKey.prefix}...
+                        </code>
+                      </div>
+                      <div>
+                        <p className="mb-1 text-muted-foreground">Last used</p>
+                        <p className="py-1">
+                          {apiKey.lastUsedAt
+                            ? formatRelativeDate(apiKey.lastUsedAt)
+                            : "No activity"}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                ))
+              : null}
+          </div>
+
+          <div className="hidden md:block">
+            <Table>
+              <TableHeader className="bg-muted/35">
+                <TableRow className="hover:bg-transparent">
+                  <TableHead className="pl-4">Name</TableHead>
+                  <TableHead>Token</TableHead>
+                  <TableHead>Permission</TableHead>
+                  <TableHead>Last used</TableHead>
+                  <TableHead>Created</TableHead>
+                  <TableHead className="w-14 pr-4 text-right">
+                    <span className="sr-only">Actions</span>
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+              {loading ? (
+                <TableRow className="hover:bg-transparent">
+                  <TableCell colSpan={6} className="h-36 text-center text-muted-foreground">
+                    Loading API keys...
+                  </TableCell>
+                </TableRow>
+              ) : null}
+              {!loading && filteredAPIKeys.length === 0 ? (
+                <TableRow className="hover:bg-transparent">
+                  <TableCell colSpan={6} className="p-0 whitespace-normal">
+                    <APIKeysEmptyState hasQuery={Boolean(query)} />
+                  </TableCell>
+                </TableRow>
+              ) : null}
+              {!loading
+                ? filteredAPIKeys.map((apiKey) => (
                     <TableRow key={apiKey.id}>
-                      <TableCell className="font-medium">{apiKey.name}</TableCell>
-                      <TableCell>
-                        {workspaceNameById.get(apiKey.workspaceId) ??
-                          apiKey.workspaceId}
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant="outline">{apiKey.prefix}</Badge>
-                      </TableCell>
-                      <TableCell>
-                        {apiKey.lastUsedAt ? formatDate(apiKey.lastUsedAt) : "nunca"}
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex justify-end">
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => revokeAPIKey(apiKey)}
-                            disabled={pending}
-                          >
-                            <XIcon data-icon="inline-start" />
-                            Revogar
-                          </Button>
+                      <TableCell className="pl-4 font-medium">
+                        <div className="flex items-center gap-3">
+                          <div className="flex size-8 shrink-0 items-center justify-center rounded-lg border bg-primary/10 text-primary">
+                            <KeyRoundIcon className="size-4" />
+                          </div>
+                          <div className="min-w-0">
+                            <p className="max-w-52 truncate">{apiKey.name}</p>
+                            <p className="max-w-52 truncate text-xs font-normal text-muted-foreground">
+                              {workspaceNameById.get(apiKey.workspaceId) ?? apiKey.workspaceId}
+                            </p>
+                          </div>
                         </div>
                       </TableCell>
+                      <TableCell>
+                        <code className="rounded-md bg-muted px-2 py-1 font-mono text-xs text-muted-foreground">
+                          {apiKey.prefix}...
+                        </code>
+                      </TableCell>
+                      <TableCell>
+                        <span className="inline-flex items-center gap-1.5 text-sm">
+                          <ShieldCheckIcon className="size-4 text-emerald-500" />
+                          Sending access
+                        </span>
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">
+                        {apiKey.lastUsedAt
+                          ? formatRelativeDate(apiKey.lastUsedAt)
+                          : "No activity"}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">
+                        {formatRelativeDate(apiKey.createdAt)}
+                      </TableCell>
+                      <TableCell className="pr-4 text-right">
+                        <APIKeyActions
+                          apiKey={apiKey}
+                          onEdit={openEditDialog}
+                          onDelete={(key) => {
+                            setError("")
+                            setDeletingKey(key)
+                          }}
+                        />
+                      </TableCell>
                     </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+                  ))
+                : null}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent className="sm:max-w-md">
+          <form onSubmit={createAPIKey}>
+            <DialogHeader>
+              <DialogTitle>Create API key</DialogTitle>
+              <DialogDescription>
+                The full key is shown once after creation. Store it somewhere secure.
+              </DialogDescription>
+            </DialogHeader>
+            <FieldGroup className="mt-5">
+              <Field>
+                <FieldLabel htmlFor="api-key-name">Name</FieldLabel>
+                <Input
+                  id="api-key-name"
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                  maxLength={80}
+                  autoFocus
+                  required
+                />
+              </Field>
+              <Field>
+                <FieldLabel>Workspace</FieldLabel>
+                <Select
+                  value={workspaceId}
+                  onValueChange={(value) => value && setWorkspaceId(value)}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Select workspace">
+                      {(value) =>
+                        availableWorkspaces.find(
+                          (workspace) => workspace.id === String(value)
+                        )?.name ?? "Select workspace"
+                      }
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      {availableWorkspaces.map((workspace) => (
+                        <SelectItem key={workspace.id} value={workspace.id}>
+                          {workspace.name}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              </Field>
+              {error ? <FieldError>{error}</FieldError> : null}
+            </FieldGroup>
+            <DialogFooter className="mt-5">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setCreateOpen(false)}
+                disabled={pending}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={pending || !workspaceId || !name.trim()}>
+                <PlusIcon data-icon="inline-start" />
+                {pending ? "Creating..." : "Create API key"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={Boolean(editingKey)} onOpenChange={(open) => !open && setEditingKey(null)}>
+        <DialogContent className="sm:max-w-md">
+          <form onSubmit={updateAPIKey}>
+            <DialogHeader>
+              <DialogTitle>Edit API key</DialogTitle>
+              <DialogDescription>
+                Rename this key so its purpose stays easy to identify.
+              </DialogDescription>
+            </DialogHeader>
+            <FieldGroup className="mt-5">
+              <Field>
+                <FieldLabel htmlFor="edit-api-key-name">Name</FieldLabel>
+                <Input
+                  id="edit-api-key-name"
+                  value={editingName}
+                  onChange={(event) => setEditingName(event.target.value)}
+                  maxLength={80}
+                  autoFocus
+                  required
+                />
+              </Field>
+              {error ? <FieldError>{error}</FieldError> : null}
+            </FieldGroup>
+            <DialogFooter className="mt-5">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setEditingKey(null)}
+                disabled={pending}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={pending || !editingName.trim()}>
+                {pending ? "Saving..." : "Save changes"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={Boolean(deletingKey)}
+        onOpenChange={(open) => !open && !pending && setDeletingKey(null)}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <div className="mb-1 flex size-9 items-center justify-center rounded-lg bg-destructive/10 text-destructive">
+              <TriangleAlertIcon className="size-4" />
             </div>
-          </CardContent>
-        </Card>
-      </div>
+            <DialogTitle>Delete API key</DialogTitle>
+            <DialogDescription>
+              <strong className="font-medium text-foreground">{deletingKey?.name}</strong>
+              {" will stop working immediately. This action cannot be undone."}
+            </DialogDescription>
+          </DialogHeader>
+          {error ? <FieldError>{error}</FieldError> : null}
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDeletingKey(null)}
+              disabled={pending}
+            >
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={deleteAPIKey} disabled={pending}>
+              <Trash2Icon data-icon="inline-start" />
+              {pending ? "Deleting..." : "Delete API key"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={Boolean(newKey)} onOpenChange={(open) => !open && setNewKey("")}>
         <DialogContent className="w-[calc(100vw-2rem)] sm:max-w-2xl">
           <DialogHeader>
-            <DialogTitle>API key gerada</DialogTitle>
+            <div className="mb-1 flex size-9 items-center justify-center rounded-lg bg-emerald-500/10 text-emerald-500">
+              <CheckIcon className="size-4" />
+            </div>
+            <DialogTitle>API key created</DialogTitle>
             <DialogDescription>
-              Use this key in the CLI. It will not be shown again.
+              Copy this key now. For security, it will not be shown again.
             </DialogDescription>
           </DialogHeader>
           <div className="flex min-w-0 gap-2">
             <Input className="min-w-0 flex-1 font-mono text-xs" value={newKey} readOnly />
             <Button
               className="shrink-0"
-              size="icon"
               variant="outline"
               onClick={copyNewKey}
               aria-label="Copy API key"
             >
-              {copied ? <CheckIcon /> : <CopyIcon />}
+              {copied ? <CheckIcon data-icon="inline-start" /> : <CopyIcon data-icon="inline-start" />}
+              {copied ? "Copied" : "Copy"}
             </Button>
           </div>
-          <div className="min-w-0 overflow-x-auto rounded-md bg-muted px-3 py-2">
+          <div className="min-w-0 overflow-x-auto rounded-lg border bg-muted/60 px-3 py-2.5">
             <code className="block w-max whitespace-nowrap font-mono text-xs leading-5">
               RUNTZ_API_KEY={newKey}
             </code>
           </div>
+          <DialogFooter>
+            <Button onClick={() => setNewKey("")}>Done</Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </div>
   )
 }
 
-function formatDate(value: string) {
-  return new Intl.DateTimeFormat("pt-BR", {
-    dateStyle: "short",
-    timeStyle: "short",
-  }).format(new Date(value))
+function APIKeyActions({
+  apiKey,
+  onEdit,
+  onDelete,
+}: {
+  apiKey: ApiKey
+  onEdit: (apiKey: ApiKey) => void
+  onDelete: (apiKey: ApiKey) => void
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={`Actions for ${apiKey.name}`}
+          />
+        }
+      >
+        <MoreHorizontalIcon />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-44">
+        <DropdownMenuItem onClick={() => onEdit(apiKey)}>
+          <PencilIcon />
+          Edit API key
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem variant="destructive" onClick={() => onDelete(apiKey)}>
+          <Trash2Icon />
+          Delete API key
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+function APIKeysEmptyState({ hasQuery }: { hasQuery: boolean }) {
+  return (
+    <Empty className="min-h-52 border-0">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <KeyRoundIcon />
+        </EmptyMedia>
+        <EmptyTitle>{hasQuery ? "No matching API keys" : "No API keys yet"}</EmptyTitle>
+        <EmptyDescription>
+          {hasQuery
+            ? "Try another name, token prefix or workspace."
+            : "Create a key to connect the Runtz CLI to this workspace."}
+        </EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  )
+}
+
+function formatRelativeDate(value: string) {
+  const date = new Date(value)
+  const elapsed = Date.now() - date.getTime()
+  const days = Math.floor(elapsed / 86_400_000)
+
+  if (days <= 0) {
+    return "Today"
+  }
+  if (days === 1) {
+    return "Yesterday"
+  }
+  if (days < 30) {
+    return `${days} days ago`
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+  }).format(date)
 }

--- a/frontend/src/app/app/settings/page.tsx
+++ b/frontend/src/app/app/settings/page.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 import {
+  ActivityIcon,
   ArrowUpRightIcon,
   CopyIcon,
   CreditCardIcon,
@@ -705,6 +706,11 @@ type UsageWindow = {
 type UsageResponse = {
   weekly: UsageWindow
   monthly: UsageWindow
+  limits: {
+    weekly: number
+    monthly: number
+  }
+  plan: "free" | "pro" | "enterprise"
   generatedAt: string
 }
 
@@ -739,40 +745,69 @@ function UsagePanel() {
 
   const weekly = usage?.weekly ?? EMPTY_USAGE_WINDOW
   const monthly = usage?.monthly ?? EMPTY_USAGE_WINDOW
-  // Weekly scans are a subset of the monthly ones, so the month is the track.
-  const busiest = Math.max(1, weekly.total, monthly.total)
+  const weeklyLimit = usage?.limits.weekly ?? 0
+  const monthlyLimit = usage?.limits.monthly ?? 0
+  const scopeDescription =
+    selectedWorkspaceId === "all"
+      ? "Usage across all workspaces you can access."
+      : "Usage for the selected workspace."
 
   return (
-    <Card className="relative max-w-xl overflow-hidden">
-      <div aria-hidden="true" className="runtz-dot-map pointer-events-none absolute inset-0 opacity-[0.06]" />
-      <CardHeader className="relative">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <CardTitle>Scans sent</CardTitle>
-            <CardDescription>
-              Counted from the ingested scans of the selected workspace.
-            </CardDescription>
+    <Card className="relative max-w-3xl overflow-hidden">
+      <div
+        aria-hidden="true"
+        className="runtz-dot-map pointer-events-none absolute inset-0 opacity-[0.045]"
+      />
+      <CardHeader className="relative border-b bg-background/35">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="flex min-w-0 gap-3">
+            <div className="flex size-9 shrink-0 items-center justify-center rounded-lg border bg-background text-primary shadow-sm">
+              <ActivityIcon className="size-4" />
+            </div>
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <CardTitle>Scan usage</CardTitle>
+                {usage ? (
+                  <Badge variant="secondary">{planLabel(usage.plan)} plan</Badge>
+                ) : null}
+              </div>
+              <CardDescription className="mt-1">
+                {scopeDescription} Limits use rolling 7 and 30 day windows.
+              </CardDescription>
+            </div>
           </div>
           <Button variant="outline" size="sm" onClick={loadUsage} disabled={pending}>
             <RefreshCcwIcon data-icon="inline-start" />
-            Atualizar
+            Refresh
           </Button>
         </div>
       </CardHeader>
-      <CardContent className="relative grid gap-3">
+      <CardContent className="relative grid gap-4 p-4 md:p-5">
         <UsageWindowRow
-          label="Weekly"
+          label="Weekly usage"
+          period="Last 7 days"
           total={weekly.total}
-          busiest={busiest}
+          limit={weeklyLimit}
           loading={pending && !usage}
         />
         <UsageWindowRow
-          label="Monthly"
+          label="Monthly usage"
+          period="Last 30 days"
           total={monthly.total}
-          busiest={busiest}
+          limit={monthlyLimit}
           loading={pending && !usage}
         />
-        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        {error ? (
+          <p className="rounded-lg border border-destructive/25 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {error}
+          </p>
+        ) : null}
+        {usage ? (
+          <p className="text-xs text-muted-foreground">
+            {Math.max(0, monthlyLimit - monthly.total).toLocaleString("en-US")} scans
+            remain in the current monthly window.
+          </p>
+        ) : null}
       </CardContent>
     </Card>
   )
@@ -780,34 +815,57 @@ function UsagePanel() {
 
 function UsageWindowRow({
   label,
+  period,
   total,
-  busiest,
+  limit,
   loading,
 }: {
   label: string
+  period: string
   total: number
-  busiest: number
+  limit: number
   loading: boolean
 }) {
-  // Both bars share the same track so the week reads as a slice of the month.
-  const width = Math.round((total / busiest) * 100)
+  const percentage = limit > 0 ? Math.min(100, (total / limit) * 100) : 0
+  const percentageLabel = Math.round(percentage)
+  const progressColor =
+    percentage >= 100
+      ? "bg-destructive"
+      : percentage >= 80
+        ? "bg-amber-500"
+        : "bg-primary"
 
   return (
-    <div className="grid gap-2 rounded-lg border bg-background/55 p-3 sm:grid-cols-[80px_minmax(0,1fr)_auto] sm:items-center sm:gap-4">
-      <span className="text-sm font-medium">{label}</span>
-      <div
-        className="h-2 overflow-hidden rounded-full bg-muted"
-        role="img"
-        aria-label={`${label}: ${total} scans`}
-      >
-        <div className="h-full rounded-full bg-primary" style={{ width: `${width}%` }} />
-      </div>
-      <div className="text-sm sm:justify-self-end">
+    <div className="grid gap-3 rounded-lg border bg-background/70 p-4 shadow-xs">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-medium">{label}</p>
+          <p className="text-xs text-muted-foreground">{period}</p>
+        </div>
         {loading ? (
-          <Skeleton className="h-5 w-10" />
+          <Skeleton className="h-6 w-28" />
         ) : (
-          <span className="font-mono">{total.toLocaleString("pt-BR")}</span>
+          <div className="text-right">
+            <p className="font-mono text-sm font-medium tabular-nums">
+              {total.toLocaleString("en-US")}
+              <span className="text-muted-foreground"> / {limit.toLocaleString("en-US")}</span>
+            </p>
+            <p className="text-xs text-muted-foreground">{percentageLabel}% used</p>
+          </div>
         )}
+      </div>
+      <div
+        className="h-2.5 overflow-hidden rounded-full bg-muted ring-1 ring-foreground/5"
+        role="progressbar"
+        aria-label={`${label}: ${total} of ${limit} scans used`}
+        aria-valuemin={0}
+        aria-valuemax={limit}
+        aria-valuenow={Math.min(total, limit)}
+      >
+        <div
+          className={`h-full rounded-full transition-[width] duration-300 motion-reduce:transition-none ${progressColor}`}
+          style={{ width: `${percentage}%` }}
+        />
       </div>
     </div>
   )

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,6 +6,7 @@ export type Workspace = {
   id: string
   name: string
   slug: string
+  kind?: string
   createdAt: string
   updatedAt: string
 }
@@ -193,7 +194,7 @@ export type ContainerScan = PackageScan & {
 }
 
 type RequestOptions = {
-  method?: "GET" | "POST" | "PATCH"
+  method?: "GET" | "POST" | "PATCH" | "DELETE"
   body?: unknown
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds enforced rolling scan allowances for Free, Pro, and Enterprise workspaces and redesigns Settings > Usage around the real plan capacity. Reworks API key management with a top-level create flow, searchable responsive list, rename support, permanent deletion with confirmation, and the requested Edit/Delete overflow menu.

Limits:
- Free: 2,500 scans per 7 days and 10,000 per 30 days
- Pro and Enterprise: 1,000,000 scans in both windows

Ingestion returns HTTP 429 once either workspace allowance is reached. Playground-generated data is excluded from usage.

## Base branch

- [x] This PR targets `dev` (or is a release promotion to `main`)

## Checklist

- [x] `cd engine && go test ./...` passes
- [x] `cd engine && go vet ./...` passes
- [x] `cd frontend && npm run lint && npm run build` passes
- [ ] `helm lint helm/runtz` passes (chart unchanged)
- [x] No secrets, tokens or personal endpoints in the diff
- [x] Docs updated (README / site docs) if behavior changed

## Generated by

- **Author:** Codex (GPT-5)
- **Task / prompt:** Add Free/Pro scan limits, improve the usage counter and redesign API key creation/edit/delete management, then deploy to dev.
- **How it was verified:** Go tests and vet; frontend lint and production build; local Docker stack; desktop/mobile screenshots at 1440, 1280 and 375px; live PATCH and DELETE endpoint checks.
- [ ] A human reviewed the full diff and takes responsibility for it

By submitting this pull request, I agree that my contribution is provided
under the project license (BUSL-1.1) as described in CONTRIBUTING.md.
