### PR TITLE
Simplify usage and improve onboarding

### DIFF
--- a/frontend/src/app/app/api-keys/page.tsx
+++ b/frontend/src/app/app/api-keys/page.tsx
@@ -10,7 +10,6 @@ import {
   PlusIcon,
   RefreshCcwIcon,
   SearchIcon,
-  ShieldCheckIcon,
   Trash2Icon,
   TriangleAlertIcon,
 } from "lucide-react"
@@ -284,7 +283,7 @@ export default function APIKeysPage() {
                 <Badge variant="secondary">{apiKeys.length}</Badge>
               </div>
               <CardDescription className="mt-1">
-                Keys are scoped to one workspace and have scan sending access.
+                Keys are scoped to one workspace.
               </CardDescription>
             </div>
             <div className="flex w-full gap-2 lg:max-w-md">
@@ -369,7 +368,6 @@ export default function APIKeysPage() {
                 <TableRow className="hover:bg-transparent">
                   <TableHead className="pl-4">Name</TableHead>
                   <TableHead>Token</TableHead>
-                  <TableHead>Permission</TableHead>
                   <TableHead>Last used</TableHead>
                   <TableHead>Created</TableHead>
                   <TableHead className="w-14 pr-4 text-right">
@@ -380,14 +378,14 @@ export default function APIKeysPage() {
               <TableBody>
               {loading ? (
                 <TableRow className="hover:bg-transparent">
-                  <TableCell colSpan={6} className="h-36 text-center text-muted-foreground">
+                  <TableCell colSpan={5} className="h-36 text-center text-muted-foreground">
                     Loading API keys...
                   </TableCell>
                 </TableRow>
               ) : null}
               {!loading && filteredAPIKeys.length === 0 ? (
                 <TableRow className="hover:bg-transparent">
-                  <TableCell colSpan={6} className="p-0 whitespace-normal">
+                  <TableCell colSpan={5} className="p-0 whitespace-normal">
                     <APIKeysEmptyState hasQuery={Boolean(query)} />
                   </TableCell>
                 </TableRow>
@@ -412,12 +410,6 @@ export default function APIKeysPage() {
                         <code className="rounded-md bg-muted px-2 py-1 font-mono text-xs text-muted-foreground">
                           {apiKey.prefix}...
                         </code>
-                      </TableCell>
-                      <TableCell>
-                        <span className="inline-flex items-center gap-1.5 text-sm">
-                          <ShieldCheckIcon className="size-4 text-emerald-500" />
-                          Sending access
-                        </span>
                       </TableCell>
                       <TableCell className="text-muted-foreground">
                         {apiKey.lastUsedAt

--- a/frontend/src/app/app/onboarding/page.tsx
+++ b/frontend/src/app/app/onboarding/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import Link from "next/link"
 import { useRouter } from "next/navigation"
 import * as React from "react"
 import {
@@ -13,6 +14,7 @@ import {
 } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   Card,
   CardContent,
@@ -31,6 +33,7 @@ export default function OnboardingPage() {
   const [copied, setCopied] = React.useState("")
   const [error, setError] = React.useState("")
   const [pending, setPending] = React.useState(false)
+  const [hideOnboarding, setHideOnboarding] = React.useState(false)
   const workspace = workspaces[0]
   const endpoint =
     deploymentMode === "cloud"
@@ -77,32 +80,23 @@ export default function OnboardingPage() {
     window.setTimeout(() => setCopied(""), 1800)
   }
 
-  async function completeOnboarding() {
-    if (!apiKey) {
+  async function leaveOnboarding(requireAPIKey: boolean) {
+    if (requireAPIKey && !apiKey) {
       return
     }
 
     setPending(true)
     setError("")
     try {
-      await apiRequest("/api/v1/me/onboarding", {
-        method: "PATCH",
-      })
+      if (hideOnboarding) {
+        await apiRequest("/api/v1/me/onboarding", {
+          method: "PATCH",
+        })
+      }
       router.replace("/app/overview")
     } catch (error) {
       setError(error instanceof Error ? error.message : "Failed to complete onboarding")
       setPending(false)
-    }
-  }
-
-  async function skipOnboarding() {
-    setPending(true)
-    try {
-      await apiRequest("/api/v1/me/onboarding", { method: "PATCH" })
-    } catch {
-      // best-effort: navigate regardless
-    } finally {
-      router.replace("/app/overview")
     }
   }
 
@@ -167,14 +161,23 @@ export default function OnboardingPage() {
               active={Boolean(apiKey)}
               complete={false}
               icon={ServerIcon}
-              title="Scan this host"
-              description="Run it from anywhere on this machine. The CLI fingerprints the installed OS packages, matches them against known CVEs and sends the report straight to your workspace."
+              title="Scan your host"
             >
-              <CommandLine
-                value={scanCommand}
-                copied={copied === "scan"}
-                onCopy={() => copy(scanCommand, "scan")}
-              />
+              <div className="flex flex-col gap-3">
+                <CommandLine
+                  value={scanCommand}
+                  copied={copied === "scan"}
+                  onCopy={() => copy(scanCommand, "scan")}
+                />
+                <Button
+                  variant="outline"
+                  className="w-fit"
+                  render={<Link href="/app/hosts" />}
+                >
+                  Access host scanning page
+                  <ArrowRightIcon data-icon="inline-end" />
+                </Button>
+              </div>
             </OnboardingStep>
           </div>
 
@@ -184,14 +187,29 @@ export default function OnboardingPage() {
             </p>
           ) : null}
 
-          <div className="mt-8 flex items-center justify-between border-t pt-5">
-            <Button variant="ghost" onClick={skipOnboarding} disabled={pending} className="text-muted-foreground">
-              Pular por agora
-            </Button>
-            <Button onClick={completeOnboarding} disabled={pending || !apiKey}>
-              Ir para o Overview
-              <ArrowRightIcon data-icon="inline-end" />
-            </Button>
+          <div className="mt-8 flex flex-col gap-4 border-t pt-5 sm:flex-row sm:items-center sm:justify-between">
+            <label className="flex cursor-pointer items-center gap-2 text-sm text-muted-foreground">
+              <Checkbox
+                checked={hideOnboarding}
+                onCheckedChange={(checked) => setHideOnboarding(Boolean(checked))}
+                disabled={pending}
+              />
+              Don&apos;t show onboarding again
+            </label>
+            <div className="flex flex-col-reverse gap-2 sm:flex-row">
+              <Button
+                variant="ghost"
+                onClick={() => leaveOnboarding(false)}
+                disabled={pending}
+                className="text-muted-foreground"
+              >
+                Skip for now
+              </Button>
+              <Button onClick={() => leaveOnboarding(true)} disabled={pending || !apiKey}>
+                Go to Overview
+                <ArrowRightIcon data-icon="inline-end" />
+              </Button>
+            </div>
           </div>
         </CardContent>
       </Card>
@@ -211,7 +229,7 @@ function OnboardingStep({
   complete: boolean
   icon: React.ComponentType<React.SVGProps<SVGSVGElement>>
   title: string
-  description: string
+  description?: string
   children: React.ReactNode
 }) {
   return (
@@ -226,9 +244,11 @@ function OnboardingStep({
       </div>
       <div>
         <h2 className="text-lg font-semibold">{title}</h2>
-        <p className="mt-1 max-w-2xl text-sm leading-6 text-muted-foreground">
-          {description}
-        </p>
+        {description ? (
+          <p className="mt-1 max-w-2xl text-sm leading-6 text-muted-foreground">
+            {description}
+          </p>
+        ) : null}
       </div>
       {children}
     </section>

--- a/frontend/src/app/app/settings/page.tsx
+++ b/frontend/src/app/app/settings/page.tsx
@@ -747,34 +747,17 @@ function UsagePanel() {
   const monthly = usage?.monthly ?? EMPTY_USAGE_WINDOW
   const weeklyLimit = usage?.limits.weekly ?? 0
   const monthlyLimit = usage?.limits.monthly ?? 0
-  const scopeDescription =
-    selectedWorkspaceId === "all"
-      ? "Usage across all workspaces you can access."
-      : "Usage for the selected workspace."
 
   return (
-    <Card className="relative max-w-3xl overflow-hidden">
-      <div
-        aria-hidden="true"
-        className="runtz-dot-map pointer-events-none absolute inset-0 opacity-[0.045]"
-      />
-      <CardHeader className="relative border-b bg-background/35">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div className="flex min-w-0 gap-3">
-            <div className="flex size-9 shrink-0 items-center justify-center rounded-lg border bg-background text-primary shadow-sm">
-              <ActivityIcon className="size-4" />
-            </div>
-            <div className="min-w-0">
-              <div className="flex flex-wrap items-center gap-2">
-                <CardTitle>Scan usage</CardTitle>
-                {usage ? (
-                  <Badge variant="secondary">{planLabel(usage.plan)} plan</Badge>
-                ) : null}
-              </div>
-              <CardDescription className="mt-1">
-                {scopeDescription} Limits use rolling 7 and 30 day windows.
-              </CardDescription>
-            </div>
+    <Card className="max-w-xl">
+      <CardHeader className="border-b">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <ActivityIcon className="size-4 text-primary" />
+            <CardTitle>Scan usage</CardTitle>
+            {usage ? (
+              <Badge variant="secondary">{planLabel(usage.plan)} plan</Badge>
+            ) : null}
           </div>
           <Button variant="outline" size="sm" onClick={loadUsage} disabled={pending}>
             <RefreshCcwIcon data-icon="inline-start" />
@@ -782,17 +765,15 @@ function UsagePanel() {
           </Button>
         </div>
       </CardHeader>
-      <CardContent className="relative grid gap-4 p-4 md:p-5">
+      <CardContent className="grid gap-5 p-4 md:p-5">
         <UsageWindowRow
           label="Weekly usage"
-          period="Last 7 days"
           total={weekly.total}
           limit={weeklyLimit}
           loading={pending && !usage}
         />
         <UsageWindowRow
           label="Monthly usage"
-          period="Last 30 days"
           total={monthly.total}
           limit={monthlyLimit}
           loading={pending && !usage}
@@ -802,12 +783,6 @@ function UsagePanel() {
             {error}
           </p>
         ) : null}
-        {usage ? (
-          <p className="text-xs text-muted-foreground">
-            {Math.max(0, monthlyLimit - monthly.total).toLocaleString("en-US")} scans
-            remain in the current monthly window.
-          </p>
-        ) : null}
       </CardContent>
     </Card>
   )
@@ -815,19 +790,16 @@ function UsagePanel() {
 
 function UsageWindowRow({
   label,
-  period,
   total,
   limit,
   loading,
 }: {
   label: string
-  period: string
   total: number
   limit: number
   loading: boolean
 }) {
   const percentage = limit > 0 ? Math.min(100, (total / limit) * 100) : 0
-  const percentageLabel = Math.round(percentage)
   const progressColor =
     percentage >= 100
       ? "bg-destructive"
@@ -836,37 +808,25 @@ function UsageWindowRow({
         : "bg-primary"
 
   return (
-    <div className="grid gap-3 rounded-lg border bg-background/70 p-4 shadow-xs">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <p className="text-sm font-medium">{label}</p>
-          <p className="text-xs text-muted-foreground">{period}</p>
-        </div>
-        {loading ? (
-          <Skeleton className="h-6 w-28" />
-        ) : (
-          <div className="text-right">
-            <p className="font-mono text-sm font-medium tabular-nums">
-              {total.toLocaleString("en-US")}
-              <span className="text-muted-foreground"> / {limit.toLocaleString("en-US")}</span>
-            </p>
-            <p className="text-xs text-muted-foreground">{percentageLabel}% used</p>
-          </div>
-        )}
-      </div>
-      <div
-        className="h-2.5 overflow-hidden rounded-full bg-muted ring-1 ring-foreground/5"
-        role="progressbar"
-        aria-label={`${label}: ${total} of ${limit} scans used`}
-        aria-valuemin={0}
-        aria-valuemax={limit}
-        aria-valuenow={Math.min(total, limit)}
-      >
+    <div className="grid gap-2">
+      <p className="text-sm font-medium">{label}</p>
+      {loading ? (
+        <Skeleton className="h-2 w-full rounded-full" />
+      ) : (
         <div
-          className={`h-full rounded-full transition-[width] duration-300 motion-reduce:transition-none ${progressColor}`}
-          style={{ width: `${percentage}%` }}
-        />
-      </div>
+          className="h-2 overflow-hidden rounded-full bg-muted"
+          role="progressbar"
+          aria-label={`${label}: ${total} of ${limit} scans used`}
+          aria-valuemin={0}
+          aria-valuemax={limit}
+          aria-valuenow={Math.min(total, limit)}
+        >
+          <div
+            className={`h-full rounded-full transition-[width] duration-300 motion-reduce:transition-none ${progressColor}`}
+            style={{ width: `${percentage}%` }}
+          />
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## What does this PR do?

Simplifies the Settings usage panel, removes the non-configurable Permission column from API Keys, and improves the host onboarding flow.

### UI changes

- Usage now shows only the plan, refresh action, Weekly/Monthly labels, and progress bars.
- API Keys no longer displays the duplicated Permission column.
- “Scan this host” is now “Scan your host”.
- Removes the long host scan explanation.
- Adds an “Access host scanning page” link to `/app/hosts`.
- Adds a “Don't show onboarding again” checkbox. When selected, leaving onboarding persists completion; the page remains available through its direct URL and the account menu.

## Base branch

- [x] This PR targets `dev` (or is a release promotion to `main`)

## Checklist

- [x] `cd frontend && npm run lint && npm run build` passes
- [x] No secrets, tokens or personal endpoints in the diff
- [x] Desktop and mobile layouts exercised locally

## Generated by

- **Author:** Codex (GPT-5)
- **Task / prompt:** Make Usage more minimal, remove API key permission display, improve host onboarding, and deploy to dev.
- **How it was verified:** Frontend lint and production build; local Docker stack; desktop/mobile screenshots; host link target check; persisted onboarding completion check.
- [ ] A human reviewed the full diff and takes responsibility for it

By submitting this pull request, I agree that my contribution is provided
under the project license (BUSL-1.1) as described in CONTRIBUTING.md.
