### PR TITLE
Show scan totals in usage bars

### DIFF
--- a/frontend/src/app/app/settings/page.tsx
+++ b/frontend/src/app/app/settings/page.tsx
@@ -809,7 +809,16 @@ function UsageWindowRow({
 
   return (
     <div className="grid gap-2">
-      <p className="text-sm font-medium">{label}</p>
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm font-medium">{label}</p>
+        {loading ? (
+          <Skeleton className="h-4 w-16" />
+        ) : (
+          <span className="text-xs font-medium tabular-nums text-muted-foreground">
+            {total}/{limit}
+          </span>
+        )}
+      </div>
       {loading ? (
         <Skeleton className="h-2 w-full rounded-full" />
       ) : (


### PR DESCRIPTION
## What does this PR do?

Adds a compact `scans/limit` counter to the right side of each weekly and monthly usage label, keeping the existing minimal layout intact.

## Base branch

- [x] This PR targets `dev` (or is a release promotion to `main`)

## Checklist

- [ ] `cd engine && go test ./...` passes
- [x] `cd frontend && npm run lint && npm run build` passes (if frontend changed)
- [ ] `helm lint helm/runtz` passes (if chart changed)
- [x] No secrets, tokens or personal endpoints in the diff
- [x] Docs updated (README / site docs) if behavior changed

## Generated by

- **Author:** Codex (GPT-5)
- **Task / prompt:** Show current scan usage and configured limit at the end of each minimal usage row.
- **How it was verified:** Ran frontend lint and production build; exercised the Settings Usage page locally at 1280×800 and 375×812 and confirmed `0/2500` and `0/10000` render without overflow.
- [ ] A human reviewed the full diff and takes responsibility for it

By submitting this pull request, I agree that my contribution is provided under the project license (BUSL-1.1) as described in CONTRIBUTING.md.