### PR TITLE
Propagate trace context from the frontend to the engine

### DIFF
--- a/frontend/src/instrumentation.ts
+++ b/frontend/src/instrumentation.ts
@@ -1,5 +1,9 @@
 import { registerOTel } from "@vercel/otel"
 
+// The engine, same value the /api proxy route resolves. Kept in sync with
+// src/app/api/[...path]/route.ts on purpose — see propagateContextUrls below.
+const BACKEND_URL = process.env.RUNTZ_BACKEND_URL ?? "http://localhost:8080"
+
 /**
  * Next.js calls this once per server process, before any request is handled.
  *
@@ -10,10 +14,24 @@ import { registerOTel } from "@vercel/otel"
  * registers no exporter at all, so `next dev` stays silent and a self-hosted
  * install sends nothing anywhere.
  *
- * The payoff is /api/[...path]: the fetch instrumentation stamps `traceparent`
- * on the proxied request, and the engine reads it back, so one trace spans the
- * browser hit, this process, the engine and the MongoDB query behind it.
+ * propagateContextUrls is what makes /api/[...path] one trace instead of two.
+ * @vercel/otel does not put `traceparent` on an outgoing fetch unless the
+ * target is explicitly allowed: off Vercel, its default list is empty and only
+ * http://localhost is trusted. Our proxy calls the engine over https on a real
+ * hostname, so without this the engine would start a fresh trace on every
+ * proxied request and the two services would never appear in one timeline.
+ *
+ * It lists the engine specifically rather than "*" so that trace headers only
+ * ever reach our own backend, never a third party the app might call
+ * server-side.
  */
 export function register() {
-  registerOTel({ serviceName: "runtz-frontend" })
+  registerOTel({
+    serviceName: "runtz-frontend",
+    instrumentationConfig: {
+      fetch: {
+        propagateContextUrls: [BACKEND_URL],
+      },
+    },
+  })
 }


### PR DESCRIPTION
## What does this PR do?

Fixes a defect in #20: the `/api` proxy produced **two disconnected traces instead of one**.

Verified against the deployed dev environment after #20 merged — every trace in SigNoz had exactly one service:

```
svcs │ traces
   1 │ 3
   1 │ 3
   1 │ 2
```

A frontend trace ended at the outgoing `fetch GET https://engine-dev.runtz.dev/...` span, and the engine started a fresh trace for the request that arrived. Both services reported fine on their own — which is why the Services page looked healthy — but they never shared a timeline.

`@vercel/otel` does not put `traceparent` on an outgoing fetch unless the target is explicitly allowed. Its own type documentation is explicit:

> By default the context is propagated **only** for the deployment URLs, all other URLs should be enabled explicitly.

Off Vercel that default list is empty and only `http://localhost` is trusted, so our https engine hostname never got the header.

The allow-list names the engine specifically rather than `"*"`, so trace headers only ever reach our own backend and never a third party the app might call server-side. It reads `RUNTZ_BACKEND_URL` — the same variable the proxy route resolves — so the two cannot drift apart.

This makes true what `helm/runtz/README.md` already claimed: one trace covering the browser request, the Next.js server, the engine and the MongoDB query.

## Base branch

- [x] This PR targets `dev` (or is a release promotion to `main`)

## Checklist

- [x] `cd engine && go test ./...` passes (engine untouched)
- [x] `cd frontend && npm run lint && npm run build` passes (if frontend changed)
- [x] `helm lint helm/runtz` passes (chart untouched)
- [x] No secrets, tokens or personal endpoints in the diff
- [x] Docs updated (README / site docs) if behavior changed — the README claim now holds

## Generated by

- **Author:** Claude (claude-opus-5)
- **Task / prompt:** Instrument runtz with OpenTelemetry against the in-cluster SigNoz collector; this PR fixes cross-service trace propagation found while verifying the dev deploy.
- **How it was verified:** `npm run lint` and `npm run build` pass. The bug itself was found by querying ClickHouse after the dev deploy (`countDistinct(serviceName)` per trace was 1 for every trace) and the cause confirmed by reading `@vercel/otel`'s propagation decision in `dist/node/index.js` and its `FetchInstrumentationConfig` types. The fix is verified the same way against dev once merged — traces spanning `runtz-frontend` → `runtz-engine` → MongoDB spans in a single `traceID`.
- [ ] A human reviewed the full diff and takes responsibility for it

By submitting this pull request, I agree that my contribution is provided
under the project license (BUSL-1.1) as described in CONTRIBUTING.md.