### PR TITLE
Add GET /api/v1/keys/verify and a runtz login onboarding step

### DIFF
--- a/engine/internal/api/api_keys.go
+++ b/engine/internal/api/api_keys.go
@@ -250,7 +250,7 @@ func (s *Server) authenticateIngest(w http.ResponseWriter, r *http.Request) (Wor
 		return Workspace{}, false
 	}
 
-	workspace, err := s.workspaceFromAPIKey(r.Context(), apiKeyValue)
+	workspace, _, err := s.workspaceFromAPIKey(r.Context(), apiKeyValue)
 	if err != nil {
 		writeError(w, http.StatusUnauthorized, "invalid api key")
 		return Workspace{}, false
@@ -268,28 +268,28 @@ func (s *Server) authenticateIngest(w http.ResponseWriter, r *http.Request) (Wor
 	return workspace, true
 }
 
-func (s *Server) workspaceFromAPIKey(ctx context.Context, rawKey string) (Workspace, error) {
+func (s *Server) workspaceFromAPIKey(ctx context.Context, rawKey string) (Workspace, APIKey, error) {
 	prefix, ok := extractAPIKeyPrefix(rawKey)
 	if !ok {
-		return Workspace{}, errors.New("invalid api key format")
+		return Workspace{}, APIKey{}, errors.New("invalid api key format")
 	}
 
 	var apiKey APIKey
 	if err := s.apiKeys.FindOne(ctx, activeAPIKeyFilterWithPrefix(prefix)).Decode(&apiKey); err != nil {
-		return Workspace{}, err
+		return Workspace{}, APIKey{}, err
 	}
 
 	keyHash := hashAPIKey(rawKey)
 	if subtle.ConstantTimeCompare([]byte(keyHash), []byte(apiKey.KeyHash)) != 1 {
-		return Workspace{}, errors.New("api key hash mismatch")
+		return Workspace{}, APIKey{}, errors.New("api key hash mismatch")
 	}
 	if !apiKeyAllowsScope(apiKey, "ingest:write") {
-		return Workspace{}, errors.New("api key scope denied")
+		return Workspace{}, APIKey{}, errors.New("api key scope denied")
 	}
 
 	var workspace Workspace
 	if err := s.workspaces.FindOne(ctx, bson.M{"_id": apiKey.WorkspaceID}).Decode(&workspace); err != nil {
-		return Workspace{}, err
+		return Workspace{}, APIKey{}, err
 	}
 
 	now := time.Now().UTC()
@@ -297,7 +297,47 @@ func (s *Server) workspaceFromAPIKey(ctx context.Context, rawKey string) (Worksp
 		"$set": bson.M{"last_used_at": now, "updated_at": now},
 	})
 
-	return workspace, nil
+	return workspace, apiKey, nil
+}
+
+// handleVerifyKey lets `runtz login` check a token before storing it locally.
+// It authenticates exactly like ingest (same active-key lookup, hash compare
+// and ingest:write scope) but counts no scan usage, and answers with the
+// workspace the key unlocks so the CLI can greet the user.
+func (s *Server) handleVerifyKey(w http.ResponseWriter, r *http.Request) {
+	apiKeyValue := apiKeyFromRequest(r)
+	if apiKeyValue == "" {
+		writeError(w, http.StatusUnauthorized, "api key required")
+		return
+	}
+
+	workspace, apiKey, err := s.workspaceFromAPIKey(r.Context(), apiKeyValue)
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "invalid api key")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, verifyKeyResponse(workspace, apiKey))
+}
+
+// verifyKeyResponse deliberately exposes less than serializeAPIKey: a scan
+// token entitles its holder to know where it lands and when it dies, not the
+// workspace's internal ids (creator, scopes, key id).
+func verifyKeyResponse(workspace Workspace, apiKey APIKey) map[string]any {
+	key := map[string]any{
+		"name":   apiKey.Name,
+		"prefix": apiKey.Prefix,
+	}
+	if apiKey.ExpiresAt != nil {
+		key["expiresAt"] = apiKey.ExpiresAt.UTC().Format(time.RFC3339)
+	}
+	return map[string]any{
+		"workspace": map[string]any{
+			"id":   workspace.ID.Hex(),
+			"name": workspace.Name,
+		},
+		"apiKey": key,
+	}
 }
 
 // globalDataScope reports whether user may read data outside the workspaces

--- a/engine/internal/api/api_keys_test.go
+++ b/engine/internal/api/api_keys_test.go
@@ -3,6 +3,8 @@ package api
 import (
 	"testing"
 	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 func TestGenerateAPIKeyFormatAndPrefix(t *testing.T) {
@@ -32,6 +34,48 @@ func TestAPIKeyAllowsScope(t *testing.T) {
 	}
 	if apiKeyAllowsScope(APIKey{Scopes: []string{"scan:read"}}, "ingest:write") {
 		t.Fatal("apiKeyAllowsScope allowed an unrelated scope")
+	}
+}
+
+func TestVerifyKeyResponseShape(t *testing.T) {
+	workspaceID := bson.NewObjectID()
+	expiresAt := time.Date(2026, 11, 4, 12, 0, 0, 0, time.UTC)
+	response := verifyKeyResponse(
+		Workspace{ID: workspaceID, Name: "Acme"},
+		APIKey{Name: "CLI key", Prefix: "rtz_live_4fa33139", ExpiresAt: &expiresAt},
+	)
+
+	workspace, ok := response["workspace"].(map[string]any)
+	if !ok {
+		t.Fatalf("workspace missing from response: %v", response)
+	}
+	if workspace["id"] != workspaceID.Hex() || workspace["name"] != "Acme" {
+		t.Fatalf("workspace = %v", workspace)
+	}
+
+	key, ok := response["apiKey"].(map[string]any)
+	if !ok {
+		t.Fatalf("apiKey missing from response: %v", response)
+	}
+	if key["name"] != "CLI key" || key["prefix"] != "rtz_live_4fa33139" {
+		t.Fatalf("apiKey = %v", key)
+	}
+	if key["expiresAt"] != "2026-11-04T12:00:00Z" {
+		t.Fatalf("expiresAt = %v, want RFC3339", key["expiresAt"])
+	}
+
+	// The token holder must not learn internal ids beyond the workspace id.
+	for _, secret := range []string{"createdBy", "scopes", "id", "keyHash"} {
+		if _, leaked := key[secret]; leaked {
+			t.Fatalf("verify response leaks apiKey.%s", secret)
+		}
+	}
+
+	// A key without expiry omits the field instead of sending a zero time.
+	response = verifyKeyResponse(Workspace{ID: workspaceID, Name: "Acme"}, APIKey{Name: "CLI key"})
+	key = response["apiKey"].(map[string]any)
+	if _, present := key["expiresAt"]; present {
+		t.Fatal("expiresAt present for a key without expiry")
 	}
 }
 

--- a/engine/internal/api/server.go
+++ b/engine/internal/api/server.go
@@ -128,6 +128,7 @@ func (s *Server) Handler() http.Handler {
 	mux.Handle("POST /api/v1/users", s.adminOnly(http.HandlerFunc(s.handleCreateUser)))
 	mux.Handle("PATCH /api/v1/users/{id}", s.adminOnly(http.HandlerFunc(s.handleUpdateUser)))
 	mux.Handle("POST /api/v1/users/{id}/invite", s.adminOnly(http.HandlerFunc(s.handleCreateInvite)))
+	mux.HandleFunc("GET /api/v1/keys/verify", s.handleVerifyKey)
 	mux.HandleFunc("POST /api/v1/ingest/sca", s.handleIngestSCA)
 	mux.HandleFunc("POST /api/v1/ingest/sast", s.handleIngestSAST)
 	mux.HandleFunc("POST /api/v1/ingest/host", s.handleIngestHost)

--- a/frontend/src/app/app/onboarding/page.tsx
+++ b/frontend/src/app/app/onboarding/page.tsx
@@ -9,6 +9,7 @@ import {
   CircleIcon,
   CopyIcon,
   KeyRoundIcon,
+  LogInIcon,
   ServerIcon,
   TerminalIcon,
 } from "lucide-react"
@@ -40,10 +41,11 @@ export default function OnboardingPage() {
       ? "https://engine.runtz.dev"
       : "http://localhost:8080"
   const tokenValue = apiKey || "rtz_live_..."
-  const scanCommand =
+  const loginCommand =
     deploymentMode === "cloud"
-      ? `runtz host --token ${tokenValue}`
-      : `runtz host --endpoint ${endpoint} --token ${tokenValue}`
+      ? `runtz login --token ${tokenValue}`
+      : `runtz login --endpoint ${endpoint} --token ${tokenValue}`
+  const scanCommand = "runtz host"
 
   async function createAPIKey() {
     if (!workspace) {
@@ -110,8 +112,8 @@ export default function OnboardingPage() {
           Scan this machine
         </h1>
         <p className="mt-2 text-sm leading-6 text-muted-foreground">
-          Generate a workspace key, install the CLI and let it scan this
-          host&apos;s own OS packages with Runtz.
+          Generate a workspace key, install the CLI, log in once and let it
+          scan this host&apos;s own OS packages with Runtz.
         </p>
       </div>
 
@@ -155,6 +157,20 @@ export default function OnboardingPage() {
                 />
                 <OSBadge />
               </div>
+            </OnboardingStep>
+
+            <OnboardingStep
+              active={Boolean(apiKey)}
+              complete={Boolean(apiKey)}
+              icon={LogInIcon}
+              title="Log in once"
+              description="runtz login verifies the key and stores it locally (~/.config/runtz), so scan commands no longer need --token. In CI/CD, keep passing the key from a secret instead."
+            >
+              <CommandLine
+                value={loginCommand}
+                copied={copied === "login"}
+                onCopy={() => copy(loginCommand, "login")}
+              />
             </OnboardingStep>
 
             <OnboardingStep


### PR DESCRIPTION
## What does this PR do?

Backs the CLI's new `runtz login` command: a token-authenticated verify endpoint plus an onboarding step that teaches the login-once flow.

- **Engine** — `GET /api/v1/keys/verify`: authenticates exactly like ingest (active-key lookup, constant-time hash compare, `ingest:write` scope, `last_used_at` touch) but counts no scan usage. Returns only the workspace id/name and the key's name, prefix and expiry — deliberately less than the session-authenticated key listing. `workspaceFromAPIKey` now also returns the key document (single existing caller adjusted).
- **Frontend** — onboarding gains a "Log in once" step (`runtz login --token ...`, with `--endpoint` in self-hosted mode) and the final step becomes plain `runtz host`.

## Base branch

- [x] This PR targets `dev` (or is a release promotion to `main`)

## Checklist

- [x] `cd engine && go test ./...` passes
- [x] `cd frontend && npm run lint && npm run build` passes (if frontend changed)
- [ ] `helm lint helm/runtz` passes (chart not changed)
- [x] No secrets, tokens or personal endpoints in the diff
- [x] Docs updated (README / site docs) if behavior changed — site docs PR in runtz.dev, CLI PR in runtz-cli

## Generated by

- **Author:** Claude (Claude Code, model claude-fable-5)
- **Task / prompt:** Make `--token` optional in the CLI via a `runtz login` flow; add a verify endpoint and update onboarding
- **How it was verified:** `go vet`/`go test` on engine (incl. new `verifyKeyResponse` shape test), frontend lint+build; full login/whoami/logout flow exercised end-to-end against a stub engine with the new CLI build
- [ ] A human reviewed the full diff and takes responsibility for it

🤖 Generated with [Claude Code](https://claude.com/claude-code)