### PR TITLE
Polish scan states and add production autoscaling

### DIFF
--- a/frontend/src/app/app/containers/[imageName]/page.tsx
+++ b/frontend/src/app/app/containers/[imageName]/page.tsx
@@ -80,7 +80,7 @@ export default function ContainerDetailPage() {
               {imageName}
             </h1>
             <p className="text-sm text-muted-foreground">
-              CVEs found in the image&apos;s latest package scan.
+              Vulnerability results from the image&apos;s latest package scan.
             </p>
           </div>
         </div>
@@ -143,7 +143,7 @@ export default function ContainerDetailPage() {
           <div className="grid gap-6 xl:grid-cols-[1fr_360px]">
             <Card>
               <CardHeader>
-                <CardTitle>CVEs found</CardTitle>
+                <CardTitle>Vulnerability results</CardTitle>
                 <CardDescription>
                   Latest scan on {formatDate(latestScan.createdAt)}
                 </CardDescription>

--- a/frontend/src/app/app/containers/page.tsx
+++ b/frontend/src/app/app/containers/page.tsx
@@ -10,6 +10,7 @@ import {
   SeverityDistribution,
   VulnerabilityTrendChart,
 } from "@/components/runtz/sca-components"
+import { FirstScanEmptyState } from "@/components/runtz/scan-empty-state"
 import { usePlatform } from "@/components/runtz/platform-context"
 import { usePackageScans } from "@/components/runtz/use-package-scans"
 import { Badge } from "@/components/ui/badge"
@@ -20,13 +21,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
-import {
-  Empty,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-} from "@/components/ui/empty"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
   Table,
@@ -117,17 +111,12 @@ export default function ContainersPage() {
           <VulnerabilityTrendChart scans={scans} />
 
           {images.length === 0 ? (
-            <Empty className="min-h-80 border">
-              <EmptyHeader>
-                <EmptyMedia variant="icon">
-                  <ContainerIcon />
-                </EmptyMedia>
-                <EmptyTitle>No images scanned</EmptyTitle>
-                <EmptyDescription>
-                  Run the container CLI against the engine to populate this panel.
-                </EmptyDescription>
-              </EmptyHeader>
-            </Empty>
+            <FirstScanEmptyState
+              title="No images scanned"
+              description="Scan a container image to start tracking vulnerable packages in this workspace."
+              command="runtz container ubuntu:22.04"
+              icon={ContainerIcon}
+            />
           ) : (
             <Card>
               <CardHeader>

--- a/frontend/src/app/app/hosts/[hostname]/page.tsx
+++ b/frontend/src/app/app/hosts/[hostname]/page.tsx
@@ -80,7 +80,7 @@ export default function HostDetailPage() {
               {hostname}
             </h1>
             <p className="text-sm text-muted-foreground">
-              CVEs found in the host&apos;s latest package scan.
+              Vulnerability results from the host&apos;s latest package scan.
             </p>
           </div>
         </div>
@@ -143,7 +143,7 @@ export default function HostDetailPage() {
           <div className="grid gap-6 xl:grid-cols-[1fr_360px]">
             <Card>
               <CardHeader>
-                <CardTitle>CVEs found</CardTitle>
+                <CardTitle>Vulnerability results</CardTitle>
                 <CardDescription>
                   Latest scan on {formatDate(latestScan.createdAt)}
                 </CardDescription>

--- a/frontend/src/app/app/hosts/page.tsx
+++ b/frontend/src/app/app/hosts/page.tsx
@@ -10,6 +10,7 @@ import {
   SeverityDistribution,
   VulnerabilityTrendChart,
 } from "@/components/runtz/sca-components"
+import { FirstScanEmptyState } from "@/components/runtz/scan-empty-state"
 import { usePlatform } from "@/components/runtz/platform-context"
 import { usePackageScans } from "@/components/runtz/use-package-scans"
 import { Badge } from "@/components/ui/badge"
@@ -20,13 +21,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
-import {
-  Empty,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-} from "@/components/ui/empty"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
   Table,
@@ -117,17 +111,12 @@ export default function HostsPage() {
           <VulnerabilityTrendChart scans={scans} />
 
           {hosts.length === 0 ? (
-            <Empty className="min-h-80 border">
-              <EmptyHeader>
-                <EmptyMedia variant="icon">
-                  <ServerIcon />
-                </EmptyMedia>
-                <EmptyTitle>No hosts scanned</EmptyTitle>
-                <EmptyDescription>
-                  Run the host CLI against the engine to populate this panel.
-                </EmptyDescription>
-              </EmptyHeader>
-            </Empty>
+            <FirstScanEmptyState
+              title="No hosts scanned"
+              description="Scan this host to start tracking vulnerable operating-system packages."
+              command="runtz host"
+              icon={ServerIcon}
+            />
           ) : (
             <Card>
               <CardHeader>

--- a/frontend/src/app/app/k8s/page.tsx
+++ b/frontend/src/app/app/k8s/page.tsx
@@ -18,7 +18,7 @@ export default function KubernetesPage() {
       targetListDescription="Click a cluster name to see the findings from its latest scan."
       inspectedTitle="Resources"
       emptyTitle="No clusters scanned"
-      emptyDescription="Run the Kubernetes CLI against the engine to populate this panel."
+      emptyDescription="Scan your cluster posture to start tracking Kubernetes security findings."
       commandLabel="runtz k8s"
       icon={ShipWheelIcon}
     />

--- a/frontend/src/app/app/sast/page.tsx
+++ b/frontend/src/app/app/sast/page.tsx
@@ -18,8 +18,8 @@ export default function SASTPage() {
       targetListDescription="Click an app name to see the findings from its latest scan."
       inspectedTitle="Files"
       emptyTitle="No apps scanned"
-      emptyDescription="Run the SAST CLI against the engine to populate this panel."
-      commandLabel="runtz sast"
+      emptyDescription="Scan your source code to start tracking security findings in this workspace."
+      commandLabel="runtz sast ./"
       icon={CodeIcon}
     />
   )

--- a/frontend/src/app/app/sca/[projectName]/page.tsx
+++ b/frontend/src/app/app/sca/[projectName]/page.tsx
@@ -76,7 +76,7 @@ export default function SCAProjectPage() {
               {projectName}
             </h1>
             <p className="text-sm text-muted-foreground">
-              CVEs found in this app&apos;s latest SCA scan.
+              Vulnerability results from this app&apos;s latest SCA scan.
             </p>
           </div>
         </div>
@@ -139,7 +139,7 @@ export default function SCAProjectPage() {
           <div className="grid gap-6 xl:grid-cols-[1fr_360px]">
             <Card>
               <CardHeader>
-                <CardTitle>CVEs found</CardTitle>
+                <CardTitle>Vulnerability results</CardTitle>
                 <CardDescription>
                   Latest scan on {formatDate(latestScan.createdAt)}
                 </CardDescription>

--- a/frontend/src/app/app/sca/page.tsx
+++ b/frontend/src/app/app/sca/page.tsx
@@ -10,6 +10,7 @@ import {
   SeverityDistribution,
   VulnerabilityTrendChart,
 } from "@/components/runtz/sca-components"
+import { FirstScanEmptyState } from "@/components/runtz/scan-empty-state"
 import { usePlatform } from "@/components/runtz/platform-context"
 import { useSCAScans } from "@/components/runtz/use-sca-scans"
 import { Badge } from "@/components/ui/badge"
@@ -20,13 +21,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
-import {
-  Empty,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-} from "@/components/ui/empty"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
   Table,
@@ -107,17 +101,12 @@ export default function SCAPage() {
           <VulnerabilityTrendChart scans={scans} />
 
           {apps.length === 0 ? (
-            <Empty className="min-h-80 border">
-              <EmptyHeader>
-                <EmptyMedia variant="icon">
-                  <RadarIcon />
-                </EmptyMedia>
-                <EmptyTitle>No apps scanned</EmptyTitle>
-                <EmptyDescription>
-                  Run the CLI against the local engine to populate this panel.
-                </EmptyDescription>
-              </EmptyHeader>
-            </Empty>
+            <FirstScanEmptyState
+              title="No apps scanned"
+              description="Scan your application dependencies to start tracking risk in this workspace."
+              command="runtz sca ./"
+              icon={RadarIcon}
+            />
           ) : (
             <Card>
               <CardHeader>

--- a/frontend/src/components/runtz/findings-scan-page.tsx
+++ b/frontend/src/components/runtz/findings-scan-page.tsx
@@ -12,6 +12,10 @@ import {
   SeverityDistribution,
   VulnerabilityTrendChart,
 } from "@/components/runtz/sca-components"
+import {
+  CleanScanState,
+  FirstScanEmptyState,
+} from "@/components/runtz/scan-empty-state"
 import { usePlatform } from "@/components/runtz/platform-context"
 import { useFindingScans } from "@/components/runtz/use-finding-scans"
 import { Badge } from "@/components/ui/badge"
@@ -22,13 +26,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
-import {
-  Empty,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-} from "@/components/ui/empty"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
   Table,
@@ -149,15 +146,12 @@ export function FindingsScanPage({
           <VulnerabilityTrendChart scans={scans} />
 
           {targets.length === 0 ? (
-            <Empty className="min-h-80 border">
-              <EmptyHeader>
-                <EmptyMedia variant="icon">
-                  <Icon />
-                </EmptyMedia>
-                <EmptyTitle>{emptyTitle}</EmptyTitle>
-                <EmptyDescription>{emptyDescription}</EmptyDescription>
-              </EmptyHeader>
-            </Empty>
+            <FirstScanEmptyState
+              title={emptyTitle}
+              description={emptyDescription}
+              command={commandLabel}
+              icon={Icon}
+            />
           ) : (
             <Card>
               <CardHeader>
@@ -237,11 +231,13 @@ export function FindingsTable({
   findings,
   title = "Latest findings",
   description,
+  scanIsClean = false,
 }: {
   scans: FindingsScan[]
   findings: Array<{ scan: FindingsScan; finding: Finding }>
   title?: string
   description?: string
+  scanIsClean?: boolean
 }) {
   return (
     <Card>
@@ -253,49 +249,57 @@ export function FindingsTable({
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Severity</TableHead>
-              <TableHead>Finding</TableHead>
-              <TableHead>Location</TableHead>
-              <TableHead>Remediation</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {findings.map(({ scan, finding }, index) => (
-              <TableRow
-                key={`${scan.id}-${finding.id}-${finding.file ?? ""}-${
-                  finding.line ?? 0
-                }-${finding.resourceName ?? ""}-${index}`}
-              >
-                <TableCell>
-                  <SeverityBadge severity={finding.severity} />
-                </TableCell>
-                <TableCell className="min-w-72">
-                  <div className="flex flex-col gap-1">
-                    <span className="font-medium">{finding.title}</span>
-                    <span className="text-xs text-muted-foreground">
-                      {finding.id}
-                      {finding.category ? ` · ${finding.category}` : ""}
-                    </span>
-                    {finding.description ? (
-                      <span className="text-xs text-muted-foreground">
-                        {finding.description}
-                      </span>
-                    ) : null}
-                  </div>
-                </TableCell>
-                <TableCell className="min-w-64">
-                  <span className="text-sm">{findingLocation(finding)}</span>
-                </TableCell>
-                <TableCell className="min-w-72 text-sm text-muted-foreground">
-                  {finding.remediation || "-"}
-                </TableCell>
+        {scanIsClean ? (
+          <CleanScanState title="Great news — no findings detected" />
+        ) : findings.length === 0 ? (
+          <div className="flex min-h-40 items-center justify-center rounded-lg border border-dashed px-6 text-center text-sm text-muted-foreground">
+            No findings match the active filters.
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Severity</TableHead>
+                <TableHead>Finding</TableHead>
+                <TableHead>Location</TableHead>
+                <TableHead>Remediation</TableHead>
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+            </TableHeader>
+            <TableBody>
+              {findings.map(({ scan, finding }, index) => (
+                <TableRow
+                  key={`${scan.id}-${finding.id}-${finding.file ?? ""}-${
+                    finding.line ?? 0
+                  }-${finding.resourceName ?? ""}-${index}`}
+                >
+                  <TableCell>
+                    <SeverityBadge severity={finding.severity} />
+                  </TableCell>
+                  <TableCell className="min-w-72">
+                    <div className="flex flex-col gap-1">
+                      <span className="font-medium">{finding.title}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {finding.id}
+                        {finding.category ? ` · ${finding.category}` : ""}
+                      </span>
+                      {finding.description ? (
+                        <span className="text-xs text-muted-foreground">
+                          {finding.description}
+                        </span>
+                      ) : null}
+                    </div>
+                  </TableCell>
+                  <TableCell className="min-w-64">
+                    <span className="text-sm">{findingLocation(finding)}</span>
+                  </TableCell>
+                  <TableCell className="min-w-72 text-sm text-muted-foreground">
+                    {finding.remediation || "-"}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
       </CardContent>
     </Card>
   )

--- a/frontend/src/components/runtz/findings-target-page.tsx
+++ b/frontend/src/components/runtz/findings-target-page.tsx
@@ -227,7 +227,8 @@ export function FindingsTargetPage({
               <FindingsTable
                 scans={[scanDetail.scan]}
                 findings={visibleFindings}
-                title="Findings found"
+                scanIsClean={latestFindings.length === 0}
+                title="Security findings"
                 description={
                   disabledCategories.size > 0
                     ? `Showing ${visibleFindings.length} of ${latestFindings.length} findings · Latest scan on ${formatDate(latestScan.createdAt)}`

--- a/frontend/src/components/runtz/package-vulnerability-explorer.tsx
+++ b/frontend/src/components/runtz/package-vulnerability-explorer.tsx
@@ -6,21 +6,14 @@ import {
   CopyIcon,
   ExternalLinkIcon,
   PackageIcon,
-  ShieldCheckIcon,
   SparklesIcon,
 } from "lucide-react"
 import * as React from "react"
 
 import { SeverityBadge } from "@/components/runtz/sca-components"
+import { CleanScanState } from "@/components/runtz/scan-empty-state"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import {
-  Empty,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-} from "@/components/ui/empty"
 import { Separator } from "@/components/ui/separator"
 import {
   Sheet,
@@ -71,19 +64,7 @@ export function PackageVulnerabilityExplorer({
   )
 
   if (groups.length === 0) {
-    return (
-      <Empty className="min-h-48 border">
-        <EmptyHeader>
-          <EmptyMedia variant="icon">
-            <ShieldCheckIcon />
-          </EmptyMedia>
-          <EmptyTitle>No vulnerabilities found</EmptyTitle>
-          <EmptyDescription>
-            The latest scan found no CVEs for the detected versions.
-          </EmptyDescription>
-        </EmptyHeader>
-      </Empty>
-    )
+    return <CleanScanState />
   }
 
   const context = {

--- a/frontend/src/components/runtz/scan-empty-state.tsx
+++ b/frontend/src/components/runtz/scan-empty-state.tsx
@@ -1,0 +1,121 @@
+"use client"
+
+import {
+  CheckIcon,
+  CopyIcon,
+  ShieldCheckIcon,
+  TerminalIcon,
+} from "lucide-react"
+import type { LucideIcon } from "lucide-react"
+import * as React from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty"
+
+export function FirstScanEmptyState({
+  title,
+  description,
+  command,
+  icon: Icon,
+}: {
+  title: string
+  description: string
+  command: string
+  icon: LucideIcon
+}) {
+  const [copied, setCopied] = React.useState(false)
+  const resetTimeout = React.useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  React.useEffect(
+    () => () => {
+      if (resetTimeout.current) {
+        clearTimeout(resetTimeout.current)
+      }
+    },
+    []
+  )
+
+  async function copyCommand() {
+    try {
+      await navigator.clipboard.writeText(command)
+      setCopied(true)
+      if (resetTimeout.current) {
+        clearTimeout(resetTimeout.current)
+      }
+      resetTimeout.current = setTimeout(() => setCopied(false), 2000)
+    } catch {
+      setCopied(false)
+    }
+  }
+
+  return (
+    <Empty className="min-h-80 border bg-card/35">
+      <EmptyHeader className="max-w-md">
+        <EmptyMedia variant="icon">
+          <Icon />
+        </EmptyMedia>
+        <EmptyTitle>{title}</EmptyTitle>
+        <EmptyDescription>{description}</EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent className="max-w-lg">
+        <div className="flex w-full flex-col gap-2 text-left">
+          <span className="text-xs font-medium text-foreground">
+            Run your first scan
+          </span>
+          <div className="flex w-full min-w-0 items-center gap-2 rounded-lg border bg-background/70 p-1.5 pl-3 shadow-sm">
+            <TerminalIcon className="size-4 shrink-0 text-primary" />
+            <code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap py-1 font-mono text-xs text-foreground sm:text-sm">
+              {command}
+            </code>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={copyCommand}
+              aria-label={copied ? "Command copied" : "Copy command"}
+            >
+              {copied ? (
+                <CheckIcon data-icon="inline-start" />
+              ) : (
+                <CopyIcon data-icon="inline-start" />
+              )}
+              <span aria-live="polite">{copied ? "Copied" : "Copy"}</span>
+            </Button>
+          </div>
+        </div>
+      </EmptyContent>
+    </Empty>
+  )
+}
+
+export function CleanScanState({
+  title = "Great news — no vulnerabilities detected",
+}: {
+  title?: string
+}) {
+  return (
+    <Empty className="min-h-48 border bg-[#34c68a]/[0.04]">
+      <EmptyHeader className="max-w-md">
+        <EmptyMedia
+          variant="icon"
+          className="bg-[#34c68a]/10 text-[#198754] dark:text-[#80d673]"
+        >
+          <ShieldCheckIcon />
+        </EmptyMedia>
+        <EmptyTitle>{title}</EmptyTitle>
+        <EmptyDescription>
+          The latest scan found no security issues in its scope. Keep scanning
+          regularly to catch new risks as your code, dependencies, and
+          environments evolve.
+        </EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  )
+}

--- a/helm/environments/prod/values.yaml
+++ b/helm/environments/prod/values.yaml
@@ -15,6 +15,19 @@
 #     --set frontend.image.tag="<version>"
 
 frontend:
+  autoscaling:
+    enabled: true
+    minReplicas: 3
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 75
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
   image:
     # Cloud build pushed to the in-cluster registry. It no longer bakes any
     # NEXT_PUBLIC_* config — everything environment-specific is served by the
@@ -37,6 +50,19 @@ frontend:
     OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=prod,service.namespace=runtz"
 
 backend:
+  autoscaling:
+    enabled: true
+    minReplicas: 3
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 75
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 768Mi
   image:
     # Generic public engine image (no build-time config).
     repository: runtzdev/runtz-engine

--- a/helm/runtz/README.md
+++ b/helm/runtz/README.md
@@ -39,6 +39,11 @@ pre-created Kubernetes Secret containing the keys `RESEND_API_KEY`,
 | `backend.image.repository` | `runtzdev/runtz-engine` | Engine image |
 | `frontend.image.repository` | `runtzdev/runtz-frontend` | Frontend image |
 | `backend.image.tag` / `frontend.image.tag` | chart `appVersion` | Image tag |
+| `backend.autoscaling.enabled` / `frontend.autoscaling.enabled` | `false` | Create a CPU-based HPA for the component |
+| `backend.autoscaling.minReplicas` / `frontend.autoscaling.minReplicas` | `1` | Minimum replicas while autoscaling |
+| `backend.autoscaling.maxReplicas` / `frontend.autoscaling.maxReplicas` | `10` | Maximum replicas while autoscaling |
+| `backend.autoscaling.targetCPUUtilizationPercentage` / `frontend.autoscaling.targetCPUUtilizationPercentage` | `70` | Target CPU utilization as a percentage of the request |
+| `backend.autoscaling.targetMemoryUtilizationPercentage` / `frontend.autoscaling.targetMemoryUtilizationPercentage` | `75` | Target memory utilization as a percentage of the request |
 | `backend.env.RUNTZ_PUBLIC_URL` | `http://localhost:3000` | Public URL of the platform |
 | `backend.env.CORS_ALLOWED_ORIGINS` | `http://localhost:3000` | Comma-separated origins |
 | `backend.env.MONGODB_URI` | in-cluster MongoDB | Set to use an external MongoDB |
@@ -50,6 +55,11 @@ pre-created Kubernetes Secret containing the keys `RESEND_API_KEY`,
 | `backend.ingress.enabled` | `false` | Engine ingress (direct API access) |
 
 See [values.yaml](values.yaml) for the complete list.
+
+Resource autoscaling requires the Kubernetes metrics API (usually Metrics
+Server) and CPU/memory requests on each autoscaled container. Set both
+requests when enabling an HPA; the runtz production overlay already defines
+them.
 
 ## OpenTelemetry
 

--- a/helm/runtz/templates/engine/deployment.yaml
+++ b/helm/runtz/templates/engine/deployment.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "runtz.componentLabels" (dict "root" . "component" "backend") | nindent 4 }}
 spec:
+  {{- if not .Values.backend.autoscaling.enabled }}
   replicas: {{ .Values.backend.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "runtz.componentSelectorLabels" (dict "root" . "component" "backend") | nindent 6 }}

--- a/helm/runtz/templates/engine/hpa.yaml
+++ b/helm/runtz/templates/engine/hpa.yaml
@@ -1,0 +1,45 @@
+{{- if and .Values.backend.enabled .Values.backend.autoscaling.enabled -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "runtz.backendName" . }}
+  labels:
+    {{- include "runtz.componentLabels" (dict "root" . "component" "backend") | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "runtz.backendName" . }}
+  minReplicas: {{ .Values.backend.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.backend.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.backend.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.backend.autoscaling.targetMemoryUtilizationPercentage }}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      selectPolicy: Max
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 60
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 25
+          periodSeconds: 60
+{{- end }}

--- a/helm/runtz/templates/frontend/deployment.yaml
+++ b/helm/runtz/templates/frontend/deployment.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "runtz.componentLabels" (dict "root" . "component" "frontend") | nindent 4 }}
 spec:
+  {{- if not .Values.frontend.autoscaling.enabled }}
   replicas: {{ .Values.frontend.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "runtz.componentSelectorLabels" (dict "root" . "component" "frontend") | nindent 6 }}

--- a/helm/runtz/templates/frontend/hpa.yaml
+++ b/helm/runtz/templates/frontend/hpa.yaml
@@ -1,0 +1,45 @@
+{{- if and .Values.frontend.enabled .Values.frontend.autoscaling.enabled -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "runtz.frontendName" . }}
+  labels:
+    {{- include "runtz.componentLabels" (dict "root" . "component" "frontend") | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "runtz.frontendName" . }}
+  minReplicas: {{ .Values.frontend.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.frontend.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.frontend.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.frontend.autoscaling.targetMemoryUtilizationPercentage }}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      selectPolicy: Max
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 60
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 25
+          periodSeconds: 60
+{{- end }}

--- a/helm/runtz/values.yaml
+++ b/helm/runtz/values.yaml
@@ -26,6 +26,12 @@ serviceAccount:
 frontend:
   enabled: true
   replicaCount: 1
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 75
   image:
     repository: runtzdev/runtz-frontend
     # Defaults to the chart appVersion when empty.
@@ -74,6 +80,12 @@ frontend:
 backend:
   enabled: true
   replicaCount: 1
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 75
   image:
     repository: runtzdev/runtz-engine
     # Defaults to the chart appVersion when empty.


### PR DESCRIPTION
## What changed

- adds reusable first-scan empty states for SCA, SAST, containers, hosts, and Kubernetes, with accurate CLI examples and copy feedback
- improves zero-finding and zero-vulnerability results with a positive continuous-scanning message
- adds production HPAs for the frontend and engine, with 3–10 replicas, 70% CPU and 75% memory targets
- defines production requests/limits and documents the autoscaling prerequisites

## Why

New workspaces should immediately show how to submit their first scan. Clean scan results should encourage continued monitoring, and production workloads need horizontal capacity and memory-pressure protection without scaling MongoDB.

## Validation

- `cd frontend && npm run lint && npm run build`
- `helm lint helm/runtz`
- `helm lint helm/runtz -f helm/environments/prod/values.yaml`
- rendered the production chart and confirmed CPU and memory metrics on both HPAs
- visually checked the empty state at 1440px and 375px

## Generated by

Codex (GPT-5) implemented the requested frontend scan-state polish and production autoscaling changes. A human must review the full diff before merging.
