### PR TITLE
Add CVE fix filters and correct scan trends

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Implemented:
 - Workspaces, users and profile settings.
 - Workspace-scoped API keys for CLI ingestion.
 - SCA scan ingestion and SCA dashboard.
+- CVE fix-availability filters across dashboards and package vulnerability results.
 - Go CLI for npm `package.json` SCA using GitHub Global Security Advisories.
 - SAST finding ingestion and dashboard.
 - Host package scan ingestion and dashboard for dpkg-based systems.
@@ -196,7 +197,8 @@ follow `1.0.0-rc1 → 1.0.0-rc2 → ... → 1.0.0`, then regular semver
 - `GET /api/v1/scans/k8s/{id}`
 
 Scan collection endpoints return lightweight metadata and the precomputed
-summary for dashboards. Use the corresponding `/{id}` endpoint when the full
+summary for dashboards, including CVE counts split by whether a patched version
+is available. Use the corresponding `/{id}` endpoint when the full
 dependencies, packages, vulnerabilities or findings payload is needed. Detail
 views may request `/{id}?view=results` to receive only the finding/CVE result
 array without the scanned inventory.

--- a/engine/internal/api/models.go
+++ b/engine/internal/api/models.go
@@ -153,13 +153,25 @@ type Finding struct {
 }
 
 type ScanSummary struct {
-	TotalDependencies int `bson:"total_dependencies" json:"totalDependencies"`
-	Vulnerabilities   int `bson:"vulnerabilities" json:"vulnerabilities"`
-	Critical          int `bson:"critical" json:"critical"`
-	High              int `bson:"high" json:"high"`
-	Medium            int `bson:"medium" json:"medium"`
-	Low               int `bson:"low" json:"low"`
-	Unknown           int `bson:"unknown" json:"unknown"`
+	TotalDependencies int                 `bson:"total_dependencies" json:"totalDependencies"`
+	Vulnerabilities   int                 `bson:"vulnerabilities" json:"vulnerabilities"`
+	Critical          int                 `bson:"critical" json:"critical"`
+	High              int                 `bson:"high" json:"high"`
+	Medium            int                 `bson:"medium" json:"medium"`
+	Low               int                 `bson:"low" json:"low"`
+	Unknown           int                 `bson:"unknown" json:"unknown"`
+	WithFix           VulnerabilityCounts `bson:"with_fix,omitempty" json:"withFix"`
+	WithoutFix        VulnerabilityCounts `bson:"without_fix,omitempty" json:"withoutFix"`
+	FixStatusComputed bool                `bson:"fix_status_computed,omitempty" json:"fixStatusComputed"`
+}
+
+type VulnerabilityCounts struct {
+	Vulnerabilities int `bson:"vulnerabilities" json:"vulnerabilities"`
+	Critical        int `bson:"critical" json:"critical"`
+	High            int `bson:"high" json:"high"`
+	Medium          int `bson:"medium" json:"medium"`
+	Low             int `bson:"low" json:"low"`
+	Unknown         int `bson:"unknown" json:"unknown"`
 }
 
 type Scan struct {

--- a/engine/internal/api/scan_summary_backfill.go
+++ b/engine/internal/api/scan_summary_backfill.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+const scanSummaryBackfillBatchSize = 100
+
+// backfillVulnerabilityFixSummaries makes the fix filter work for scans that
+// predate the with_fix/without_fix summary fields. It reads only the result
+// array for documents that have never been backfilled and writes compact
+// counters, so list endpoints can keep excluding large vulnerability arrays.
+func (s *Server) backfillVulnerabilityFixSummaries(ctx context.Context) error {
+	cursor, err := s.scans.Find(
+		ctx,
+		bson.M{
+			"type":                        bson.M{"$in": []string{"sca", "host", "container"}},
+			"summary.fix_status_computed": bson.M{"$ne": true},
+		},
+		options.Find().SetProjection(bson.M{"_id": 1, "vulnerabilities": 1}),
+	)
+	if err != nil {
+		return fmt.Errorf("find scan summaries to backfill: %w", err)
+	}
+	defer closeCursor(ctx, cursor)
+
+	models := make([]mongo.WriteModel, 0, scanSummaryBackfillBatchSize)
+	flush := func() error {
+		if len(models) == 0 {
+			return nil
+		}
+		if _, err := s.scans.BulkWrite(
+			ctx,
+			models,
+			options.BulkWrite().SetOrdered(false),
+		); err != nil {
+			return fmt.Errorf("backfill scan fix summaries: %w", err)
+		}
+		models = models[:0]
+		return nil
+	}
+
+	for cursor.Next(ctx) {
+		var scan struct {
+			ID              bson.ObjectID   `bson:"_id"`
+			Vulnerabilities []Vulnerability `bson:"vulnerabilities"`
+		}
+		if err := cursor.Decode(&scan); err != nil {
+			return fmt.Errorf("decode scan summary backfill row: %w", err)
+		}
+
+		summary := buildSummary(nil, scan.Vulnerabilities)
+		models = append(models, mongo.NewUpdateOneModel().
+			SetFilter(bson.M{"_id": scan.ID}).
+			SetUpdate(bson.M{"$set": bson.M{
+				"summary.with_fix":            summary.WithFix,
+				"summary.without_fix":         summary.WithoutFix,
+				"summary.fix_status_computed": true,
+			}}))
+		if len(models) == scanSummaryBackfillBatchSize {
+			if err := flush(); err != nil {
+				return err
+			}
+		}
+	}
+	if err := cursor.Err(); err != nil {
+		return fmt.Errorf("iterate scan summaries to backfill: %w", err)
+	}
+
+	return flush()
+}

--- a/engine/internal/api/scan_summary_test.go
+++ b/engine/internal/api/scan_summary_test.go
@@ -1,0 +1,46 @@
+package api
+
+import "testing"
+
+func TestBuildSummarySplitsVulnerabilitiesByFixAvailability(t *testing.T) {
+	t.Parallel()
+
+	vulnerabilities := []Vulnerability{
+		{ID: "CVE-1", Severity: "critical", FirstPatchedVersion: "2.0.0"},
+		{ID: "CVE-2", Severity: "HIGH", FirstPatchedVersion: "  "},
+		{ID: "CVE-3", Severity: "medium"},
+		{ID: "CVE-4", Severity: "unexpected", FirstPatchedVersion: "1.4.1"},
+	}
+
+	summary := buildSummary([]Dependency{{Name: "example"}}, vulnerabilities)
+
+	if !summary.FixStatusComputed {
+		t.Fatal("FixStatusComputed = false, want true")
+	}
+	if summary.TotalDependencies != 1 || summary.Vulnerabilities != 4 {
+		t.Fatalf(
+			"summary totals = (%d dependencies, %d vulnerabilities), want (1, 4)",
+			summary.TotalDependencies,
+			summary.Vulnerabilities,
+		)
+	}
+	if summary.Critical != 1 || summary.High != 1 || summary.Medium != 1 || summary.Unknown != 1 {
+		t.Fatalf("severity summary = %+v, want one critical, high, medium, and unknown", summary)
+	}
+	if summary.WithFix.Vulnerabilities != 2 || summary.WithFix.Critical != 1 || summary.WithFix.Unknown != 1 {
+		t.Fatalf("with-fix summary = %+v, want two vulnerabilities", summary.WithFix)
+	}
+	if summary.WithoutFix.Vulnerabilities != 2 || summary.WithoutFix.High != 1 || summary.WithoutFix.Medium != 1 {
+		t.Fatalf("without-fix summary = %+v, want two vulnerabilities", summary.WithoutFix)
+	}
+}
+
+func TestBuildFindingSummaryDoesNotClassifyFindingsAsCVEs(t *testing.T) {
+	t.Parallel()
+
+	summary := buildFindingSummary(3, []Finding{{ID: "SAST-1", Severity: "high"}})
+
+	if summary.WithFix.Vulnerabilities != 0 || summary.WithoutFix.Vulnerabilities != 0 {
+		t.Fatalf("finding fix summaries = (%+v, %+v), want both empty", summary.WithFix, summary.WithoutFix)
+	}
+}

--- a/engine/internal/api/server.go
+++ b/engine/internal/api/server.go
@@ -81,6 +81,9 @@ func New(ctx context.Context, cfg config.Config) (*Server, error) {
 	if err := server.ensureIndexes(ctx); err != nil {
 		return nil, err
 	}
+	if err := server.backfillVulnerabilityFixSummaries(ctx); err != nil {
+		return nil, err
+	}
 
 	server.startLicenseHeartbeat(ctx)
 
@@ -1253,21 +1256,11 @@ func buildSummary(dependencies []Dependency, vulnerabilities []Vulnerability) Sc
 	summary := ScanSummary{
 		TotalDependencies: len(dependencies),
 		Vulnerabilities:   len(vulnerabilities),
+		FixStatusComputed: true,
 	}
 
 	for _, vulnerability := range vulnerabilities {
-		switch strings.ToLower(vulnerability.Severity) {
-		case "critical":
-			summary.Critical++
-		case "high":
-			summary.High++
-		case "medium":
-			summary.Medium++
-		case "low":
-			summary.Low++
-		default:
-			summary.Unknown++
-		}
+		addVulnerabilityToSummary(&summary, vulnerability)
 	}
 
 	return summary
@@ -1277,24 +1270,40 @@ func buildPackageSummary(packages []Package, vulnerabilities []Vulnerability) Sc
 	summary := ScanSummary{
 		TotalDependencies: len(packages),
 		Vulnerabilities:   len(vulnerabilities),
+		FixStatusComputed: true,
 	}
 
 	for _, vulnerability := range vulnerabilities {
-		switch strings.ToLower(vulnerability.Severity) {
-		case "critical":
-			summary.Critical++
-		case "high":
-			summary.High++
-		case "medium":
-			summary.Medium++
-		case "low":
-			summary.Low++
-		default:
-			summary.Unknown++
-		}
+		addVulnerabilityToSummary(&summary, vulnerability)
 	}
 
 	return summary
+}
+
+func addVulnerabilityToSummary(summary *ScanSummary, vulnerability Vulnerability) {
+	counts := &summary.WithoutFix
+	if strings.TrimSpace(vulnerability.FirstPatchedVersion) != "" {
+		counts = &summary.WithFix
+	}
+
+	counts.Vulnerabilities++
+	switch strings.ToLower(strings.TrimSpace(vulnerability.Severity)) {
+	case "critical":
+		summary.Critical++
+		counts.Critical++
+	case "high":
+		summary.High++
+		counts.High++
+	case "medium":
+		summary.Medium++
+		counts.Medium++
+	case "low":
+		summary.Low++
+		counts.Low++
+	default:
+		summary.Unknown++
+		counts.Unknown++
+	}
 }
 
 func buildFindingSummary(totalScanned int, findings []Finding) ScanSummary {

--- a/frontend/src/app/app/containers/[imageName]/page.tsx
+++ b/frontend/src/app/app/containers/[imageName]/page.tsx
@@ -17,6 +17,10 @@ import { PackageVulnerabilityExplorer } from "@/components/runtz/package-vulnera
 import { usePlatform } from "@/components/runtz/platform-context"
 import { usePackageScans } from "@/components/runtz/use-package-scans"
 import { useScanDetail } from "@/components/runtz/use-scan-detail"
+import {
+  CVEFixFilterSwitches,
+  useVulnerabilityFilter,
+} from "@/components/runtz/vulnerability-filter"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -39,9 +43,11 @@ import {
   getContainerTargetName,
 } from "@/lib/package-scans"
 import { formatDate } from "@/lib/sca"
+import { filterScanSummary } from "@/lib/dashboard"
 
 export default function ContainerDetailPage() {
   const { basePath } = usePlatform()
+  const { filter } = useVulnerabilityFilter()
   const params = useParams<{ imageName: string }>()
   const imageName = React.useMemo(
     () => decodeParam(params.imageName),
@@ -53,7 +59,11 @@ export default function ContainerDetailPage() {
     [imageName, scans]
   )
   const latestScan = imageScans[0]
-  const latestSummary = latestScan?.summary
+  const latestSummary = React.useMemo(
+    () =>
+      latestScan ? filterScanSummary(latestScan.summary, filter) : undefined,
+    [filter, latestScan]
+  )
   const scanDetail = useScanDetail("container", latestScan)
 
   return (
@@ -138,15 +148,18 @@ export default function ContainerDetailPage() {
             />
           </DashboardSummaryGrid>
 
-          <VulnerabilityTrendChart scans={imageScans} />
+          <VulnerabilityTrendChart scans={imageScans} filter={filter} />
 
           <div className="grid gap-6 xl:grid-cols-[1fr_360px]">
             <Card>
-              <CardHeader>
-                <CardTitle>Vulnerability results</CardTitle>
-                <CardDescription>
-                  Latest scan on {formatDate(latestScan.createdAt)}
-                </CardDescription>
+              <CardHeader className="flex flex-col justify-between gap-4 sm:flex-row sm:items-start">
+                <div>
+                  <CardTitle>Vulnerability results</CardTitle>
+                  <CardDescription>
+                    Latest scan on {formatDate(latestScan.createdAt)}
+                  </CardDescription>
+                </div>
+                <CVEFixFilterSwitches />
               </CardHeader>
               <CardContent>
                 {scanDetail.loading ? (
@@ -197,6 +210,7 @@ export default function ContainerDetailPage() {
                 description="Recent history for this image."
                 getTitle={(scan) => scan.targetName || scan.projectName || imageName}
                 packageLabel="packages"
+                supportsFixFilter
               />
             </div>
           </div>

--- a/frontend/src/app/app/containers/page.tsx
+++ b/frontend/src/app/app/containers/page.tsx
@@ -13,6 +13,10 @@ import {
 import { FirstScanEmptyState } from "@/components/runtz/scan-empty-state"
 import { usePlatform } from "@/components/runtz/platform-context"
 import { usePackageScans } from "@/components/runtz/use-package-scans"
+import {
+  CVEFixFilterSwitches,
+  useVulnerabilityFilter,
+} from "@/components/runtz/vulnerability-filter"
 import { Badge } from "@/components/ui/badge"
 import {
   Card,
@@ -35,20 +39,27 @@ import {
   groupPackageScans,
   summarizePackageTargets,
 } from "@/lib/package-scans"
+import { aggregateSummaries, filterScanSummary } from "@/lib/dashboard"
 import { formatDate } from "@/lib/sca"
-import { aggregateSummaries } from "@/lib/dashboard"
 
 export default function ContainersPage() {
   const { basePath } = usePlatform()
+  const { filter } = useVulnerabilityFilter()
   const { scans, loading, error } = usePackageScans("container")
   const images = React.useMemo(
     () => groupPackageScans(scans, getContainerTargetName),
     [scans]
   )
-  const totals = React.useMemo(() => summarizePackageTargets(images), [images])
+  const totals = React.useMemo(
+    () => summarizePackageTargets(images, filter),
+    [filter, images]
+  )
   const severitySummary = React.useMemo(
-    () => aggregateSummaries(images.map((image) => image.latestScan.summary)),
-    [images]
+    () =>
+      aggregateSummaries(
+        images.map((image) => filterScanSummary(image.latestScan.summary, filter))
+      ),
+    [filter, images]
   )
 
   return (
@@ -108,7 +119,7 @@ export default function ContainersPage() {
             />
           </DashboardSummaryGrid>
 
-          <VulnerabilityTrendChart scans={scans} />
+          <VulnerabilityTrendChart scans={scans} filter={filter} />
 
           {images.length === 0 ? (
             <FirstScanEmptyState
@@ -119,12 +130,15 @@ export default function ContainersPage() {
             />
           ) : (
             <Card>
-              <CardHeader>
-                <CardTitle>Images</CardTitle>
-                <CardDescription>
-                  Click an image name to see the CVE list from its latest
-                  scan.
-                </CardDescription>
+              <CardHeader className="flex flex-col justify-between gap-4 sm:flex-row sm:items-start">
+                <div>
+                  <CardTitle>Images</CardTitle>
+                  <CardDescription>
+                    Click an image name to see the CVE list from its latest
+                    scan.
+                  </CardDescription>
+                </div>
+                <CVEFixFilterSwitches />
               </CardHeader>
               <CardContent>
                 <Table>
@@ -139,8 +153,14 @@ export default function ContainersPage() {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {images.map((image) => (
-                      <TableRow key={image.targetName}>
+                    {images.map((image) => {
+                      const summary = filterScanSummary(
+                        image.latestScan.summary,
+                        filter
+                      )
+
+                      return (
+                        <TableRow key={image.targetName}>
                         <TableCell className="min-w-72">
                           <div className="flex min-w-0 flex-col gap-1">
                             <Link
@@ -161,15 +181,15 @@ export default function ContainersPage() {
                           <div className="flex items-center gap-4">
                             <Badge
                               variant={
-                                image.latestScan.summary.vulnerabilities > 0
+                                summary.vulnerabilities > 0
                                   ? "secondary"
                                   : "outline"
                               }
                             >
-                              {image.latestScan.summary.vulnerabilities} vulns
+                              {summary.vulnerabilities} vulns
                             </Badge>
                             <SeverityDistribution
-                              summary={image.latestScan.summary}
+                              summary={summary}
                               className="min-w-56"
                             />
                           </div>
@@ -184,8 +204,9 @@ export default function ContainersPage() {
                         <TableCell>
                           {formatDate(image.latestScan.createdAt)}
                         </TableCell>
-                      </TableRow>
-                    ))}
+                        </TableRow>
+                      )
+                    })}
                   </TableBody>
                 </Table>
               </CardContent>

--- a/frontend/src/app/app/hosts/[hostname]/page.tsx
+++ b/frontend/src/app/app/hosts/[hostname]/page.tsx
@@ -17,6 +17,10 @@ import { PackageVulnerabilityExplorer } from "@/components/runtz/package-vulnera
 import { usePlatform } from "@/components/runtz/platform-context"
 import { usePackageScans } from "@/components/runtz/use-package-scans"
 import { useScanDetail } from "@/components/runtz/use-scan-detail"
+import {
+  CVEFixFilterSwitches,
+  useVulnerabilityFilter,
+} from "@/components/runtz/vulnerability-filter"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -39,9 +43,11 @@ import {
   getHostTargetName,
 } from "@/lib/package-scans"
 import { formatDate } from "@/lib/sca"
+import { filterScanSummary } from "@/lib/dashboard"
 
 export default function HostDetailPage() {
   const { basePath } = usePlatform()
+  const { filter } = useVulnerabilityFilter()
   const params = useParams<{ hostname: string }>()
   const hostname = React.useMemo(
     () => decodeParam(params.hostname),
@@ -53,7 +59,11 @@ export default function HostDetailPage() {
     [hostname, scans]
   )
   const latestScan = hostScans[0]
-  const latestSummary = latestScan?.summary
+  const latestSummary = React.useMemo(
+    () =>
+      latestScan ? filterScanSummary(latestScan.summary, filter) : undefined,
+    [filter, latestScan]
+  )
   const scanDetail = useScanDetail("host", latestScan)
 
   return (
@@ -138,15 +148,18 @@ export default function HostDetailPage() {
             />
           </DashboardSummaryGrid>
 
-          <VulnerabilityTrendChart scans={hostScans} />
+          <VulnerabilityTrendChart scans={hostScans} filter={filter} />
 
           <div className="grid gap-6 xl:grid-cols-[1fr_360px]">
             <Card>
-              <CardHeader>
-                <CardTitle>Vulnerability results</CardTitle>
-                <CardDescription>
-                  Latest scan on {formatDate(latestScan.createdAt)}
-                </CardDescription>
+              <CardHeader className="flex flex-col justify-between gap-4 sm:flex-row sm:items-start">
+                <div>
+                  <CardTitle>Vulnerability results</CardTitle>
+                  <CardDescription>
+                    Latest scan on {formatDate(latestScan.createdAt)}
+                  </CardDescription>
+                </div>
+                <CVEFixFilterSwitches />
               </CardHeader>
               <CardContent>
                 {scanDetail.loading ? (
@@ -191,6 +204,7 @@ export default function HostDetailPage() {
                 description="Recent history for this host."
                 getTitle={(scan) => scan.targetName || scan.projectName || hostname}
                 packageLabel="packages"
+                supportsFixFilter
               />
             </div>
           </div>

--- a/frontend/src/app/app/hosts/page.tsx
+++ b/frontend/src/app/app/hosts/page.tsx
@@ -13,6 +13,10 @@ import {
 import { FirstScanEmptyState } from "@/components/runtz/scan-empty-state"
 import { usePlatform } from "@/components/runtz/platform-context"
 import { usePackageScans } from "@/components/runtz/use-package-scans"
+import {
+  CVEFixFilterSwitches,
+  useVulnerabilityFilter,
+} from "@/components/runtz/vulnerability-filter"
 import { Badge } from "@/components/ui/badge"
 import {
   Card,
@@ -35,20 +39,27 @@ import {
   groupPackageScans,
   summarizePackageTargets,
 } from "@/lib/package-scans"
+import { aggregateSummaries, filterScanSummary } from "@/lib/dashboard"
 import { formatDate } from "@/lib/sca"
-import { aggregateSummaries } from "@/lib/dashboard"
 
 export default function HostsPage() {
   const { basePath } = usePlatform()
+  const { filter } = useVulnerabilityFilter()
   const { scans, loading, error } = usePackageScans("host")
   const hosts = React.useMemo(
     () => groupPackageScans(scans, getHostTargetName),
     [scans]
   )
-  const totals = React.useMemo(() => summarizePackageTargets(hosts), [hosts])
+  const totals = React.useMemo(
+    () => summarizePackageTargets(hosts, filter),
+    [filter, hosts]
+  )
   const severitySummary = React.useMemo(
-    () => aggregateSummaries(hosts.map((host) => host.latestScan.summary)),
-    [hosts]
+    () =>
+      aggregateSummaries(
+        hosts.map((host) => filterScanSummary(host.latestScan.summary, filter))
+      ),
+    [filter, hosts]
   )
 
   return (
@@ -108,7 +119,7 @@ export default function HostsPage() {
             />
           </DashboardSummaryGrid>
 
-          <VulnerabilityTrendChart scans={scans} />
+          <VulnerabilityTrendChart scans={scans} filter={filter} />
 
           {hosts.length === 0 ? (
             <FirstScanEmptyState
@@ -119,11 +130,14 @@ export default function HostsPage() {
             />
           ) : (
             <Card>
-              <CardHeader>
-                <CardTitle>Hosts</CardTitle>
-                <CardDescription>
-                  Click a hostname to see the CVE list from its latest scan.
-                </CardDescription>
+              <CardHeader className="flex flex-col justify-between gap-4 sm:flex-row sm:items-start">
+                <div>
+                  <CardTitle>Hosts</CardTitle>
+                  <CardDescription>
+                    Click a hostname to see the CVE list from its latest scan.
+                  </CardDescription>
+                </div>
+                <CVEFixFilterSwitches />
               </CardHeader>
               <CardContent>
                 <Table>
@@ -138,8 +152,14 @@ export default function HostsPage() {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {hosts.map((host) => (
-                      <TableRow key={host.targetName}>
+                    {hosts.map((host) => {
+                      const summary = filterScanSummary(
+                        host.latestScan.summary,
+                        filter
+                      )
+
+                      return (
+                        <TableRow key={host.targetName}>
                         <TableCell className="min-w-64">
                           <div className="flex min-w-0 flex-col gap-1">
                             <Link
@@ -160,15 +180,15 @@ export default function HostsPage() {
                           <div className="flex items-center gap-4">
                             <Badge
                               variant={
-                                host.latestScan.summary.vulnerabilities > 0
+                                summary.vulnerabilities > 0
                                   ? "secondary"
                                   : "outline"
                               }
                             >
-                              {host.latestScan.summary.vulnerabilities} vulns
+                              {summary.vulnerabilities} vulns
                             </Badge>
                             <SeverityDistribution
-                              summary={host.latestScan.summary}
+                              summary={summary}
                               className="min-w-56"
                             />
                           </div>
@@ -183,8 +203,9 @@ export default function HostsPage() {
                         <TableCell>
                           {formatDate(host.latestScan.createdAt)}
                         </TableCell>
-                      </TableRow>
-                    ))}
+                        </TableRow>
+                      )
+                    })}
                   </TableBody>
                 </Table>
               </CardContent>

--- a/frontend/src/app/app/overview/page.tsx
+++ b/frontend/src/app/app/overview/page.tsx
@@ -21,6 +21,10 @@ import { usePlatform } from "@/components/runtz/platform-context"
 import { useFindingScans } from "@/components/runtz/use-finding-scans"
 import { usePackageScans } from "@/components/runtz/use-package-scans"
 import { useSCAScans } from "@/components/runtz/use-sca-scans"
+import {
+  CVEFixFilterSwitches,
+  useVulnerabilityFilter,
+} from "@/components/runtz/vulnerability-filter"
 import { Badge } from "@/components/ui/badge"
 import {
   Card,
@@ -30,7 +34,7 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
-import { aggregateSummaries } from "@/lib/dashboard"
+import { aggregateSummaries, filterScanSummary } from "@/lib/dashboard"
 import {
   getContainerTargetName,
   getHostTargetName,
@@ -41,6 +45,7 @@ import { groupScansByProject } from "@/lib/sca"
 
 export default function OverviewPage() {
   const { basePath } = usePlatform()
+  const { filter } = useVulnerabilityFilter()
   const sca = useSCAScans()
   const sast = useFindingScans("sast")
   const containers = usePackageScans("container")
@@ -65,13 +70,23 @@ export default function OverviewPage() {
   )
   const latestSummaries = React.useMemo(
     () => [
-      ...scaProjects.map((project) => project.latestScan.summary),
-      ...sastProjects.map((project) => project.latestScan.summary),
-      ...containerImages.map((image) => image.latestScan.summary),
-      ...hostTargets.map((host) => host.latestScan.summary),
-      ...k8sTargets.map((target) => target.latestScan.summary),
+      ...scaProjects.map((project) =>
+        filterScanSummary(project.latestScan.summary, filter)
+      ),
+      ...sastProjects.map((project) =>
+        filterScanSummary(project.latestScan.summary, filter)
+      ),
+      ...containerImages.map((image) =>
+        filterScanSummary(image.latestScan.summary, filter)
+      ),
+      ...hostTargets.map((host) =>
+        filterScanSummary(host.latestScan.summary, filter)
+      ),
+      ...k8sTargets.map((target) =>
+        filterScanSummary(target.latestScan.summary, filter)
+      ),
     ],
-    [containerImages, hostTargets, k8sTargets, sastProjects, scaProjects]
+    [containerImages, filter, hostTargets, k8sTargets, sastProjects, scaProjects]
   )
   const totals = React.useMemo(
     () => aggregateSummaries(latestSummaries),
@@ -93,20 +108,23 @@ export default function OverviewPage() {
 
   return (
     <div className="flex flex-col gap-6 p-4 md:p-6">
-      <div className="flex flex-col gap-2">
-        <div className="flex items-center gap-2">
-          <Badge variant="outline">PLATFORM</Badge>
-          <Badge>Overview</Badge>
+      <div className="flex flex-col justify-between gap-4 lg:flex-row lg:items-end">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-2">
+            <Badge variant="outline">PLATFORM</Badge>
+            <Badge>Overview</Badge>
+          </div>
+          <div>
+            <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-normal">
+              <LayoutDashboardIcon className="size-5 text-primary" />
+              Overview
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Overview of scans and vulnerabilities across all assets.
+            </p>
+          </div>
         </div>
-        <div>
-          <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-normal">
-            <LayoutDashboardIcon className="size-5 text-primary" />
-            Overview
-          </h1>
-          <p className="text-sm text-muted-foreground">
-            Overview of scans and vulnerabilities across all assets.
-          </p>
-        </div>
+        <CVEFixFilterSwitches />
       </div>
 
       {error ? (
@@ -141,7 +159,7 @@ export default function OverviewPage() {
             />
           </DashboardSummaryGrid>
 
-          <VulnerabilityTrendChart scans={scans} />
+          <VulnerabilityTrendChart scans={scans} filter={filter} />
 
           <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
             <ScanFamilyCard

--- a/frontend/src/app/app/sca/[projectName]/page.tsx
+++ b/frontend/src/app/app/sca/[projectName]/page.tsx
@@ -17,6 +17,10 @@ import { PackageVulnerabilityExplorer } from "@/components/runtz/package-vulnera
 import { usePlatform } from "@/components/runtz/platform-context"
 import { useScanDetail } from "@/components/runtz/use-scan-detail"
 import { useSCAScans } from "@/components/runtz/use-sca-scans"
+import {
+  CVEFixFilterSwitches,
+  useVulnerabilityFilter,
+} from "@/components/runtz/vulnerability-filter"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -35,9 +39,11 @@ import {
 } from "@/components/ui/empty"
 import { Skeleton } from "@/components/ui/skeleton"
 import { filterScansByProject, formatDate } from "@/lib/sca"
+import { filterScanSummary } from "@/lib/dashboard"
 
 export default function SCAProjectPage() {
   const { basePath } = usePlatform()
+  const { filter } = useVulnerabilityFilter()
   const params = useParams<{ projectName: string }>()
   const projectName = React.useMemo(
     () => decodeProjectName(params.projectName),
@@ -49,7 +55,11 @@ export default function SCAProjectPage() {
     [projectName, scans]
   )
   const latestScan = projectScans[0]
-  const latestSummary = latestScan?.summary
+  const latestSummary = React.useMemo(
+    () =>
+      latestScan ? filterScanSummary(latestScan.summary, filter) : undefined,
+    [filter, latestScan]
+  )
   const scanDetail = useScanDetail("sca", latestScan)
 
   return (
@@ -134,15 +144,18 @@ export default function SCAProjectPage() {
             />
           </DashboardSummaryGrid>
 
-          <VulnerabilityTrendChart scans={projectScans} />
+          <VulnerabilityTrendChart scans={projectScans} filter={filter} />
 
           <div className="grid gap-6 xl:grid-cols-[1fr_360px]">
             <Card>
-              <CardHeader>
-                <CardTitle>Vulnerability results</CardTitle>
-                <CardDescription>
-                  Latest scan on {formatDate(latestScan.createdAt)}
-                </CardDescription>
+              <CardHeader className="flex flex-col justify-between gap-4 sm:flex-row sm:items-start">
+                <div>
+                  <CardTitle>Vulnerability results</CardTitle>
+                  <CardDescription>
+                    Latest scan on {formatDate(latestScan.createdAt)}
+                  </CardDescription>
+                </div>
+                <CVEFixFilterSwitches />
               </CardHeader>
               <CardContent>
                 {scanDetail.loading ? (
@@ -163,6 +176,7 @@ export default function SCAProjectPage() {
               <LatestScansCard
                 scans={projectScans}
                 description="Recent history for this app."
+                supportsFixFilter
               />
             </div>
           </div>

--- a/frontend/src/app/app/sca/page.tsx
+++ b/frontend/src/app/app/sca/page.tsx
@@ -13,6 +13,10 @@ import {
 import { FirstScanEmptyState } from "@/components/runtz/scan-empty-state"
 import { usePlatform } from "@/components/runtz/platform-context"
 import { useSCAScans } from "@/components/runtz/use-sca-scans"
+import {
+  CVEFixFilterSwitches,
+  useVulnerabilityFilter,
+} from "@/components/runtz/vulnerability-filter"
 import { Badge } from "@/components/ui/badge"
 import {
   Card,
@@ -30,17 +34,24 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { aggregateSummaries, filterScanSummary } from "@/lib/dashboard"
 import { formatDate, groupScansByProject, summarizeProjects } from "@/lib/sca"
-import { aggregateSummaries } from "@/lib/dashboard"
 
 export default function SCAPage() {
   const { basePath } = usePlatform()
+  const { filter } = useVulnerabilityFilter()
   const { scans, loading, error } = useSCAScans()
   const apps = React.useMemo(() => groupScansByProject(scans), [scans])
-  const totals = React.useMemo(() => summarizeProjects(apps), [apps])
+  const totals = React.useMemo(
+    () => summarizeProjects(apps, filter),
+    [apps, filter]
+  )
   const severitySummary = React.useMemo(
-    () => aggregateSummaries(apps.map((app) => app.latestScan.summary)),
-    [apps]
+    () =>
+      aggregateSummaries(
+        apps.map((app) => filterScanSummary(app.latestScan.summary, filter))
+      ),
+    [apps, filter]
   )
 
   return (
@@ -98,7 +109,7 @@ export default function SCAPage() {
             />
           </DashboardSummaryGrid>
 
-          <VulnerabilityTrendChart scans={scans} />
+          <VulnerabilityTrendChart scans={scans} filter={filter} />
 
           {apps.length === 0 ? (
             <FirstScanEmptyState
@@ -109,11 +120,14 @@ export default function SCAPage() {
             />
           ) : (
             <Card>
-              <CardHeader>
-                <CardTitle>Apps</CardTitle>
-                <CardDescription>
-                  Click an app name to see the CVE list from its latest scan.
-                </CardDescription>
+              <CardHeader className="flex flex-col justify-between gap-4 sm:flex-row sm:items-start">
+                <div>
+                  <CardTitle>Apps</CardTitle>
+                  <CardDescription>
+                    Click an app name to see the CVE list from its latest scan.
+                  </CardDescription>
+                </div>
+                <CVEFixFilterSwitches />
               </CardHeader>
               <CardContent>
                 <Table>
@@ -127,48 +141,59 @@ export default function SCAPage() {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {apps.map((app) => (
-                      <TableRow key={app.projectName}>
-                        <TableCell className="min-w-64">
-                          <div className="flex min-w-0 flex-col gap-1">
-                            <Link
-                              className="inline-flex items-center gap-2 font-medium text-primary underline-offset-4 hover:underline"
-                              href={`${basePath}/sca/${encodeURIComponent(
-                                app.projectName
-                              )}`}
-                            >
-                              <span className="truncate">{app.projectName}</span>
-                              <ArrowRightIcon />
-                            </Link>
-                            <span className="truncate text-xs text-muted-foreground">
-                              {app.workspaceNames.join(", ")}
-                            </span>
-                          </div>
-                        </TableCell>
-                        <TableCell className="min-w-72">
-                          <div className="flex items-center gap-4">
-                            <Badge
-                              variant={
-                                app.latestScan.summary.vulnerabilities > 0
-                                  ? "secondary"
-                                  : "outline"
-                              }
-                            >
-                              {app.latestScan.summary.vulnerabilities} vulns
-                            </Badge>
-                            <SeverityDistribution
-                              summary={app.latestScan.summary}
-                              className="min-w-56"
-                            />
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          {app.latestScan.summary.totalDependencies}
-                        </TableCell>
-                        <TableCell>{app.scans.length}</TableCell>
-                        <TableCell>{formatDate(app.latestScan.createdAt)}</TableCell>
-                      </TableRow>
-                    ))}
+                    {apps.map((app) => {
+                      const summary = filterScanSummary(
+                        app.latestScan.summary,
+                        filter
+                      )
+
+                      return (
+                        <TableRow key={app.projectName}>
+                          <TableCell className="min-w-64">
+                            <div className="flex min-w-0 flex-col gap-1">
+                              <Link
+                                className="inline-flex items-center gap-2 font-medium text-primary underline-offset-4 hover:underline"
+                                href={`${basePath}/sca/${encodeURIComponent(
+                                  app.projectName
+                                )}`}
+                              >
+                                <span className="truncate">
+                                  {app.projectName}
+                                </span>
+                                <ArrowRightIcon />
+                              </Link>
+                              <span className="truncate text-xs text-muted-foreground">
+                                {app.workspaceNames.join(", ")}
+                              </span>
+                            </div>
+                          </TableCell>
+                          <TableCell className="min-w-72">
+                            <div className="flex items-center gap-4">
+                              <Badge
+                                variant={
+                                  summary.vulnerabilities > 0
+                                    ? "secondary"
+                                    : "outline"
+                                }
+                              >
+                                {summary.vulnerabilities} vulns
+                              </Badge>
+                              <SeverityDistribution
+                                summary={summary}
+                                className="min-w-56"
+                              />
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            {app.latestScan.summary.totalDependencies}
+                          </TableCell>
+                          <TableCell>{app.scans.length}</TableCell>
+                          <TableCell>
+                            {formatDate(app.latestScan.createdAt)}
+                          </TableCell>
+                        </TableRow>
+                      )
+                    })}
                   </TableBody>
                 </Table>
               </CardContent>

--- a/frontend/src/components/runtz/package-vulnerability-explorer.tsx
+++ b/frontend/src/components/runtz/package-vulnerability-explorer.tsx
@@ -5,6 +5,7 @@ import {
   ChevronRightIcon,
   CopyIcon,
   ExternalLinkIcon,
+  ListFilterIcon,
   PackageIcon,
   SparklesIcon,
 } from "lucide-react"
@@ -12,9 +13,17 @@ import * as React from "react"
 
 import { SeverityBadge } from "@/components/runtz/sca-components"
 import { CleanScanState } from "@/components/runtz/scan-empty-state"
+import { useVulnerabilityFilter } from "@/components/runtz/vulnerability-filter"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty"
 import {
   Sheet,
   SheetContent,
@@ -33,6 +42,7 @@ import {
 import type { Vulnerability } from "@/lib/api"
 import {
   buildRemediationPrompt,
+  filterVulnerabilitiesByFix,
   groupVulnerabilitiesByPackage,
   referenceLabel,
   vulnerabilityReferences,
@@ -52,9 +62,14 @@ export function PackageVulnerabilityExplorer({
   osVersion,
   packageManager,
 }: PackageVulnerabilityExplorerProps) {
+  const { filter, setFilter } = useVulnerabilityFilter()
+  const filteredVulnerabilities = React.useMemo(
+    () => filterVulnerabilitiesByFix(vulnerabilities, filter),
+    [filter, vulnerabilities]
+  )
   const groups = React.useMemo(
-    () => groupVulnerabilitiesByPackage(vulnerabilities),
-    [vulnerabilities]
+    () => groupVulnerabilitiesByPackage(filteredVulnerabilities),
+    [filteredVulnerabilities]
   )
   const [selectedKey, setSelectedKey] = React.useState<string>()
   const lastTriggerRef = React.useRef<HTMLButtonElement | null>(null)
@@ -63,8 +78,27 @@ export function PackageVulnerabilityExplorer({
     [groups, selectedKey]
   )
 
-  if (groups.length === 0) {
+  if (vulnerabilities.length === 0) {
     return <CleanScanState />
+  }
+
+  if (groups.length === 0) {
+    return (
+      <Empty className="min-h-56 border">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <ListFilterIcon />
+          </EmptyMedia>
+          <EmptyTitle>No CVEs match this filter</EmptyTitle>
+          <EmptyDescription>
+            This scan has no vulnerabilities in the selected fix category.
+          </EmptyDescription>
+        </EmptyHeader>
+        <Button variant="outline" size="sm" onClick={() => setFilter("all")}>
+          Show all CVEs
+        </Button>
+      </Empty>
+    )
   }
 
   const context = {
@@ -95,7 +129,7 @@ export function PackageVulnerabilityExplorer({
     <>
       <div className="mb-3 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
         <span>
-          {vulnerabilities.length} occurrences consolidated into {groups.length}{" "}
+          {filteredVulnerabilities.length} occurrences consolidated into {groups.length}{" "}
           {groups.length === 1 ? "package" : "packages"}
         </span>
         <span>Select a package to investigate and remediate</span>

--- a/frontend/src/components/runtz/platform-context.tsx
+++ b/frontend/src/components/runtz/platform-context.tsx
@@ -2,6 +2,8 @@
 
 import * as React from "react"
 
+import { VulnerabilityFilterProvider } from "@/components/runtz/vulnerability-filter"
+
 export type PlatformMode = "app" | "playground"
 
 type PlatformContextValue = {
@@ -37,7 +39,7 @@ export function PlatformProvider({
 
   return (
     <PlatformContext.Provider value={value}>
-      {children}
+      <VulnerabilityFilterProvider>{children}</VulnerabilityFilterProvider>
     </PlatformContext.Provider>
   )
 }

--- a/frontend/src/components/runtz/sca-components.tsx
+++ b/frontend/src/components/runtz/sca-components.tsx
@@ -4,8 +4,11 @@ import * as React from "react"
 import {
   ActivityIcon,
   ChartSplineIcon,
+  MinusIcon,
   PackageIcon,
   ShieldAlertIcon,
+  TrendingDownIcon,
+  TrendingUpIcon,
 } from "lucide-react"
 
 import { Badge } from "@/components/ui/badge"
@@ -24,6 +27,7 @@ import {
   EmptyTitle,
 } from "@/components/ui/empty"
 import { Skeleton } from "@/components/ui/skeleton"
+import { useVulnerabilityFilter } from "@/components/runtz/vulnerability-filter"
 import {
   Tooltip,
   TooltipContent,
@@ -31,7 +35,12 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import type { ScanSummary } from "@/lib/api"
-import type { TrendScan } from "@/lib/dashboard"
+import {
+  aggregateSummaries,
+  filterScanSummary,
+  type CVEFixFilter,
+  type TrendScan,
+} from "@/lib/dashboard"
 import {
   countSeverity,
   formatDate,
@@ -254,19 +263,34 @@ const TREND_SERIES = [
 // Render order bottom to top so critical is the topmost visual layer.
 const STACK_ORDER = ["unknown", "low", "medium", "high", "critical"] as const
 
-export function VulnerabilityTrendChart({ scans }: { scans: TrendScan[] }) {
+export function VulnerabilityTrendChart({
+  scans,
+  filter = "all",
+}: {
+  scans: TrendScan[]
+  filter?: CVEFixFilter
+}) {
   return (
     <div className="grid gap-4 xl:grid-cols-[minmax(0,3fr)_minmax(22rem,2fr)]">
-      <VulnerabilityChart scans={scans} />
+      <VulnerabilityChart scans={scans} filter={filter} />
       <DailyScansChart scans={scans} />
     </div>
   )
 }
 
-function VulnerabilityChart({ scans }: { scans: TrendScan[] }) {
+function VulnerabilityChart({
+  scans,
+  filter,
+}: {
+  scans: TrendScan[]
+  filter: CVEFixFilter
+}) {
   const [period, setPeriod] = React.useState<TrendPeriod>(30)
   const [hoveredIndex, setHoveredIndex] = React.useState<number | null>(null)
-  const chart = React.useMemo(() => buildTrendChart(scans, period), [period, scans])
+  const chart = React.useMemo(
+    () => buildTrendChart(scans, period, filter),
+    [filter, period, scans]
+  )
   const hoveredDay = hoveredIndex === null ? null : chart.days[hoveredIndex]
 
   return (
@@ -279,7 +303,7 @@ function VulnerabilityChart({ scans }: { scans: TrendScan[] }) {
               Vulnerability trend
             </CardTitle>
             <CardDescription>
-              Severities found in scans received each day.
+              Latest known severity state per asset each day.
             </CardDescription>
           </div>
           <TrendPeriodSelector
@@ -620,7 +644,11 @@ function TrendPeriodSelector({
   )
 }
 
-function buildTrendChart(scans: TrendScan[], period: TrendPeriod) {
+function buildTrendChart(
+  scans: TrendScan[],
+  period: TrendPeriod,
+  filter: CVEFixFilter
+) {
   const width = 862
   const height = 270
   const left = 42
@@ -642,29 +670,37 @@ function buildTrendChart(scans: TrendScan[], period: TrendPeriod) {
       unknown: 0,
     }
   })
-  const byDay = new Map(days.map((day) => [day.key, day]))
+  const orderedScans = scans
+    .map((scan, index) => ({
+      scan,
+      index,
+      timestamp: new Date(scan.createdAt).getTime(),
+    }))
+    .filter(({ timestamp }) => Number.isFinite(timestamp))
+    .sort((left, right) => left.timestamp - right.timestamp)
+  const latestByAsset = new Map<string, ScanSummary>()
+  let scanIndex = 0
 
-  for (const scan of scans) {
-    const day = byDay.get(dayKey(new Date(scan.createdAt)))
-    if (!day) {
-      continue
-    }
-    day.scans += 1
-    for (const series of TREND_SERIES) {
-      day[series.key] += scan.summary[series.key]
-    }
-  }
-
-  // Forward-fill: days with no scan carry the last known vulnerability state.
-  // This shows "the vulnerability debt is still there even if we didn't scan today."
-  const lastSeen: Record<string, number> = { critical: 0, high: 0, medium: 0, low: 0, unknown: 0 }
-  let seenAny = false
   for (const day of days) {
-    if (day.scans > 0) {
-      seenAny = true
-      for (const s of TREND_SERIES) lastSeen[s.key] = day[s.key]
-    } else if (seenAny) {
-      for (const s of TREND_SERIES) day[s.key] = lastSeen[s.key]
+    const nextDay = new Date(day.date)
+    nextDay.setDate(nextDay.getDate() + 1)
+
+    while (
+      scanIndex < orderedScans.length &&
+      orderedScans[scanIndex].timestamp < nextDay.getTime()
+    ) {
+      const current = orderedScans[scanIndex]
+      latestByAsset.set(
+        trendAssetKey(current.scan, current.index),
+        filterScanSummary(current.scan.summary, filter)
+      )
+      scanIndex++
+    }
+
+    const summary = aggregateSummaries(Array.from(latestByAsset.values()))
+    day.scans = latestByAsset.size
+    for (const series of TREND_SERIES) {
+      day[series.key] = summary[series.key]
     }
   }
 
@@ -743,6 +779,23 @@ function buildTrendChart(scans: TrendScan[], period: TrendPeriod) {
       }))
       .filter((_, index) => index % Math.max(1, Math.floor(period / 6)) === 0),
   }
+}
+
+function trendAssetKey(scan: TrendScan, index: number) {
+  const targetName =
+    scan.hostname?.trim() ||
+    scan.imageName?.trim() ||
+    scan.targetName?.trim() ||
+    scan.imageRef?.trim() ||
+    scan.projectName?.trim()
+
+  if (targetName) {
+    return [scan.type || "scan", scan.workspaceId || "workspace", targetName].join(
+      ":"
+    )
+  }
+
+  return scan.id || `scan-${index}`
 }
 
 function buildDailyScansChart(scans: TrendScan[], period: TrendPeriod) {
@@ -903,6 +956,7 @@ export function LatestScansCard({
   getTitle = (scan) => scan.projectName || scan.targetName || "scan",
   packageLabel = "deps",
   findingLabel = "vulns",
+  supportsFixFilter = false,
 }: {
   scans: Array<{
     id: string
@@ -920,7 +974,15 @@ export function LatestScansCard({
   }) => string
   packageLabel?: string
   findingLabel?: string
+  supportsFixFilter?: boolean
 }) {
+  const { filter } = useVulnerabilityFilter()
+  const activeFilter = supportsFixFilter ? filter : "all"
+  const visibleScans = scans.slice(0, 8).map((scan) => ({
+    ...scan,
+    filteredSummary: filterScanSummary(scan.summary, activeFilter),
+  }))
+
   return (
     <Card>
       <CardHeader>
@@ -929,34 +991,76 @@ export function LatestScansCard({
       </CardHeader>
       <CardContent>
         <div className="flex flex-col gap-3">
-          {scans.slice(0, 8).map((scan) => (
-            <div
-              key={scan.id}
-              className="flex items-start gap-3 rounded-lg border p-3"
-            >
-              <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted">
-                <PackageIcon />
+          {visibleScans.map((scan, index) => {
+            const previousSummary = visibleScans[index + 1]?.filteredSummary
+            const delta = previousSummary
+              ? scan.filteredSummary.vulnerabilities -
+                previousSummary.vulnerabilities
+              : null
+
+            return (
+              <div
+                key={scan.id}
+                className="flex items-start gap-3 rounded-lg border p-3"
+              >
+                <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted">
+                  <PackageIcon />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-medium">
+                    {getTitle(scan)}
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    {formatDate(scan.createdAt)}
+                  </div>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    <Badge variant="outline">
+                      {scan.summary.totalDependencies} {packageLabel}
+                    </Badge>
+                    <Badge variant="secondary">
+                      {scan.filteredSummary.vulnerabilities} {findingLabel}
+                    </Badge>
+                    <VulnerabilityDelta delta={delta} />
+                  </div>
+                  <SeverityDistribution
+                    summary={scan.filteredSummary}
+                    className="mt-3 max-w-none"
+                  />
+                </div>
               </div>
-              <div className="min-w-0 flex-1">
-                <div className="truncate text-sm font-medium">
-                  {getTitle(scan)}
-                </div>
-                <div className="text-xs text-muted-foreground">
-                  {formatDate(scan.createdAt)}
-                </div>
-                <div className="mt-2 flex flex-wrap gap-2">
-                  <Badge variant="outline">
-                    {scan.summary.totalDependencies} {packageLabel}
-                  </Badge>
-                  <Badge variant="secondary">
-                    {scan.summary.vulnerabilities} {findingLabel}
-                  </Badge>
-                </div>
-              </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
       </CardContent>
     </Card>
+  )
+}
+
+function VulnerabilityDelta({ delta }: { delta: number | null }) {
+  if (delta === null) {
+    return null
+  }
+
+  if (delta > 0) {
+    return (
+      <Badge variant="destructive" aria-label={`${delta} more vulnerabilities`}>
+        <TrendingUpIcon data-icon="inline-start" />+{delta}
+      </Badge>
+    )
+  }
+
+  if (delta < 0) {
+    return (
+      <Badge variant="secondary" aria-label={`${Math.abs(delta)} fewer vulnerabilities`}>
+        <TrendingDownIcon data-icon="inline-start" />
+        {delta}
+      </Badge>
+    )
+  }
+
+  return (
+    <Badge variant="outline" aria-label="No vulnerability count change">
+      <MinusIcon data-icon="inline-start" />0
+    </Badge>
   )
 }

--- a/frontend/src/components/runtz/vulnerability-filter.tsx
+++ b/frontend/src/components/runtz/vulnerability-filter.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+import * as React from "react"
+
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import type { CVEFixFilter } from "@/lib/dashboard"
+import { cn } from "@/lib/utils"
+
+const CVE_FIX_FILTER_STORAGE_KEY = "runtz_cve_fix_filter"
+
+type VulnerabilityFilterContextValue = {
+  filter: CVEFixFilter
+  setFilter: (filter: CVEFixFilter) => void
+}
+
+const VulnerabilityFilterContext =
+  React.createContext<VulnerabilityFilterContextValue | null>(null)
+
+export function VulnerabilityFilterProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const [filter, setFilterState] = React.useState<CVEFixFilter>("all")
+
+  React.useEffect(() => {
+    const stored = window.localStorage.getItem(CVE_FIX_FILTER_STORAGE_KEY)
+    if (isCVEFixFilter(stored)) {
+      setFilterState(stored)
+    }
+  }, [])
+
+  const setFilter = React.useCallback((nextFilter: CVEFixFilter) => {
+    setFilterState(nextFilter)
+    window.localStorage.setItem(CVE_FIX_FILTER_STORAGE_KEY, nextFilter)
+  }, [])
+
+  const value = React.useMemo(
+    () => ({ filter, setFilter }),
+    [filter, setFilter]
+  )
+
+  return (
+    <VulnerabilityFilterContext.Provider value={value}>
+      {children}
+    </VulnerabilityFilterContext.Provider>
+  )
+}
+
+export function useVulnerabilityFilter() {
+  const context = React.useContext(VulnerabilityFilterContext)
+  if (!context) {
+    throw new Error(
+      "useVulnerabilityFilter must be used inside VulnerabilityFilterProvider"
+    )
+  }
+  return context
+}
+
+export function CVEFixFilterSwitches({ className }: { className?: string }) {
+  const { filter, setFilter } = useVulnerabilityFilter()
+  const includesWithFix = filter !== "without-fix"
+  const includesWithoutFix = filter !== "with-fix"
+
+  return (
+    <div
+      className={cn(
+        "flex w-fit flex-wrap items-center gap-x-4 gap-y-2 rounded-lg border bg-muted/35 px-3 py-2",
+        className
+      )}
+      role="group"
+      aria-label="Filter CVEs by fix availability"
+    >
+      <span className="text-xs font-medium text-muted-foreground">
+        CVE filter
+      </span>
+      <div className="flex items-center gap-2">
+        <Switch
+          id="cve-filter-with-fix"
+          checked={includesWithFix}
+          disabled={includesWithFix && !includesWithoutFix}
+          onCheckedChange={(checked) =>
+            setFilter(checked ? "all" : "without-fix")
+          }
+        />
+        <Label htmlFor="cve-filter-with-fix" className="text-xs">
+          With fix
+        </Label>
+      </div>
+      <div className="flex items-center gap-2">
+        <Switch
+          id="cve-filter-without-fix"
+          checked={includesWithoutFix}
+          disabled={includesWithoutFix && !includesWithFix}
+          onCheckedChange={(checked) =>
+            setFilter(checked ? "all" : "with-fix")
+          }
+        />
+        <Label htmlFor="cve-filter-without-fix" className="text-xs">
+          No fix yet
+        </Label>
+      </div>
+    </div>
+  )
+}
+
+function isCVEFixFilter(value: string | null): value is CVEFixFilter {
+  return value === "all" || value === "with-fix" || value === "without-fix"
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -89,6 +89,18 @@ export type ScanSummary = {
   medium: number
   low: number
   unknown: number
+  withFix?: VulnerabilityCounts
+  withoutFix?: VulnerabilityCounts
+  fixStatusComputed?: boolean
+}
+
+export type VulnerabilityCounts = {
+  vulnerabilities: number
+  critical: number
+  high: number
+  medium: number
+  low: number
+  unknown: number
 }
 
 export type ScanPackage = {
@@ -244,6 +256,7 @@ export function clearClientState() {
 
   window.localStorage.removeItem("runtz_workspace_id")
   window.localStorage.removeItem("runtz_workspace_filter")
+  window.localStorage.removeItem("runtz_cve_fix_filter")
 }
 
 export async function signOut() {

--- a/frontend/src/lib/dashboard.ts
+++ b/frontend/src/lib/dashboard.ts
@@ -1,6 +1,16 @@
-import type { ScanSummary } from "@/lib/api"
+import type { ScanSummary, VulnerabilityCounts } from "@/lib/api"
+
+export type CVEFixFilter = "all" | "with-fix" | "without-fix"
 
 export type TrendScan = {
+  id?: string
+  type?: string
+  workspaceId?: string
+  projectName?: string
+  targetName?: string
+  hostname?: string
+  imageName?: string
+  imageRef?: string
   createdAt: string
   summary: ScanSummary
 }
@@ -28,4 +38,31 @@ export function aggregateSummaries(summaries: ScanSummary[]): ScanSummary {
     total.unknown += summary.unknown
     return total
   }, emptyScanSummary())
+}
+
+export function filterScanSummary(
+  summary: ScanSummary,
+  filter: CVEFixFilter
+): ScanSummary {
+  if (filter === "all") {
+    return summary
+  }
+
+  const counts = filter === "with-fix" ? summary.withFix : summary.withoutFix
+  return summaryFromCounts(summary.totalDependencies, counts)
+}
+
+function summaryFromCounts(
+  totalDependencies: number,
+  counts?: VulnerabilityCounts
+): ScanSummary {
+  return {
+    totalDependencies,
+    vulnerabilities: counts?.vulnerabilities ?? 0,
+    critical: counts?.critical ?? 0,
+    high: counts?.high ?? 0,
+    medium: counts?.medium ?? 0,
+    low: counts?.low ?? 0,
+    unknown: counts?.unknown ?? 0,
+  }
 }

--- a/frontend/src/lib/package-scans.ts
+++ b/frontend/src/lib/package-scans.ts
@@ -1,4 +1,5 @@
 import type { PackageScan, ScanSummary } from "@/lib/api"
+import { filterScanSummary, type CVEFixFilter } from "@/lib/dashboard"
 import { SEVERITY_KEYS, countSeverity, sortScansDesc, type SeverityKey } from "@/lib/sca"
 
 export type PackageScanTarget<TScan extends PackageScan = PackageScan> = {
@@ -65,11 +66,12 @@ export function filterPackageScansByTarget<TScan extends PackageScan>(
 }
 
 export function summarizePackageTargets(
-  targets: PackageScanTarget[]
+  targets: PackageScanTarget[],
+  filter: CVEFixFilter = "all"
 ): PackageScanTotals {
   return targets.reduce(
     (acc, target) => {
-      const summary = target.latestScan.summary
+      const summary = filterScanSummary(target.latestScan.summary, filter)
       acc.scans += target.scans.length
       acc.packages += summary.totalDependencies
       acc.vulnerabilities += summary.vulnerabilities

--- a/frontend/src/lib/package-vulnerabilities.ts
+++ b/frontend/src/lib/package-vulnerabilities.ts
@@ -1,4 +1,5 @@
 import type { Vulnerability } from "@/lib/api"
+import type { CVEFixFilter } from "@/lib/dashboard"
 import type { SeverityKey } from "@/lib/sca"
 
 const SEVERITY_WEIGHT: Record<SeverityKey, number> = {
@@ -71,9 +72,7 @@ export function groupVulnerabilitiesByPackage(
           )
         ),
         highestSeverity,
-        fixableCount: deduplicated.filter((vulnerability) =>
-          Boolean(vulnerability.firstPatchedVersion?.trim())
-        ).length,
+        fixableCount: deduplicated.filter(vulnerabilityHasFix).length,
         vulnerabilities: deduplicated.sort(compareVulnerabilities),
       }
     })
@@ -83,6 +82,24 @@ export function groupVulnerabilitiesByPackage(
         severityWeight(left.highestSeverity)
       return severityDifference || left.name.localeCompare(right.name)
     })
+}
+
+export function filterVulnerabilitiesByFix(
+  vulnerabilities: Vulnerability[],
+  filter: CVEFixFilter
+) {
+  if (filter === "all") {
+    return vulnerabilities
+  }
+
+  const wantsFix = filter === "with-fix"
+  return vulnerabilities.filter(
+    (vulnerability) => vulnerabilityHasFix(vulnerability) === wantsFix
+  )
+}
+
+export function vulnerabilityHasFix(vulnerability: Vulnerability) {
+  return Boolean(vulnerability.firstPatchedVersion?.trim())
 }
 
 export function vulnerabilityReferences(vulnerability: Vulnerability) {

--- a/frontend/src/lib/sca.ts
+++ b/frontend/src/lib/sca.ts
@@ -1,4 +1,5 @@
 import type { SCAScan, ScanSummary } from "@/lib/api"
+import { filterScanSummary, type CVEFixFilter } from "@/lib/dashboard"
 
 export type SeverityKey = "critical" | "high" | "medium" | "low" | "unknown"
 
@@ -68,10 +69,13 @@ export function filterScansByProject(scans: SCAScan[], projectName: string) {
   )
 }
 
-export function summarizeProjects(projects: SCAProject[]): SCAOverviewTotals {
+export function summarizeProjects(
+  projects: SCAProject[],
+  filter: CVEFixFilter = "all"
+): SCAOverviewTotals {
   return projects.reduce(
     (acc, project) => {
-      const summary = project.latestScan.summary
+      const summary = filterScanSummary(project.latestScan.summary, filter)
       acc.scans += project.scans.length
       acc.dependencies += summary.totalDependencies
       acc.vulnerabilities += summary.vulnerabilities


### PR DESCRIPTION
## What does this PR do?

Adds a persistent CVE fix-availability filter across Overview, SCA, host, container, and package vulnerability result views.

- Adds independent **With fix** and **No fix yet** switches; both enabled shows all CVEs.
- Updates summary cards, severity distributions, trends, asset tables, latest-scan cards, and package results together.
- Adds severity distributions and scan-over-scan vulnerability deltas to **Latest scans**.
- Stores compact with-fix/without-fix severity counters for new scans and backfills historical package scans.
- Corrects the vulnerability trend to retain the latest state per asset per day instead of summing every repeated scan submission.
- Documents the new summary behavior.

The inflated trend was caused by treating every scan run as a separate vulnerability inventory. Repeated scans remain in history and in **Scans per day**, while the vulnerability trend now represents the latest known state of each asset.

## Base branch

- [x] This PR targets `dev` (or is a release promotion to `main`)

## Checklist

- [x] `cd engine && go test ./...` passes
- [x] `cd engine && go vet ./...` passes
- [x] `cd frontend && npm run lint && npm run build` passes
- [x] Helm chart unchanged (not applicable)
- [x] No secrets, tokens or personal endpoints in the diff
- [x] Docs updated (README / site docs) if behavior changed

## Generated by

- **Author:** Codex (GPT-5)
- **Task / prompt:** Add scan comparison visuals, global CVE fix filters, correct inflated vulnerability totals, and deploy to dev.
- **How it was verified:** Full Go tests and vet; frontend lint and production build; local Docker stack; visual inspection of Overview, SCA list, and SCA detail; Playground summary invariant validation.
- [ ] A human reviewed the full diff and takes responsibility for it

By submitting this pull request, I agree that my contribution is provided
under the project license (BUSL-1.1) as described in CONTRIBUTING.md.
