### PR TITLE
Simplify the unfixed CVE filter

### DIFF
--- a/frontend/src/app/app/containers/[imageName]/page.tsx
+++ b/frontend/src/app/app/containers/[imageName]/page.tsx
@@ -18,7 +18,7 @@ import { usePlatform } from "@/components/runtz/platform-context"
 import { usePackageScans } from "@/components/runtz/use-package-scans"
 import { useScanDetail } from "@/components/runtz/use-scan-detail"
 import {
-  CVEFixFilterSwitches,
+  UnfixedCVEsSwitch,
   useVulnerabilityFilter,
 } from "@/components/runtz/vulnerability-filter"
 import { Badge } from "@/components/ui/badge"
@@ -159,7 +159,7 @@ export default function ContainerDetailPage() {
                     Latest scan on {formatDate(latestScan.createdAt)}
                   </CardDescription>
                 </div>
-                <CVEFixFilterSwitches />
+                <UnfixedCVEsSwitch />
               </CardHeader>
               <CardContent>
                 {scanDetail.loading ? (

--- a/frontend/src/app/app/containers/page.tsx
+++ b/frontend/src/app/app/containers/page.tsx
@@ -14,7 +14,7 @@ import { FirstScanEmptyState } from "@/components/runtz/scan-empty-state"
 import { usePlatform } from "@/components/runtz/platform-context"
 import { usePackageScans } from "@/components/runtz/use-package-scans"
 import {
-  CVEFixFilterSwitches,
+  UnfixedCVEsSwitch,
   useVulnerabilityFilter,
 } from "@/components/runtz/vulnerability-filter"
 import { Badge } from "@/components/ui/badge"
@@ -138,7 +138,7 @@ export default function ContainersPage() {
                     scan.
                   </CardDescription>
                 </div>
-                <CVEFixFilterSwitches />
+                <UnfixedCVEsSwitch />
               </CardHeader>
               <CardContent>
                 <Table>

--- a/frontend/src/app/app/hosts/[hostname]/page.tsx
+++ b/frontend/src/app/app/hosts/[hostname]/page.tsx
@@ -18,7 +18,7 @@ import { usePlatform } from "@/components/runtz/platform-context"
 import { usePackageScans } from "@/components/runtz/use-package-scans"
 import { useScanDetail } from "@/components/runtz/use-scan-detail"
 import {
-  CVEFixFilterSwitches,
+  UnfixedCVEsSwitch,
   useVulnerabilityFilter,
 } from "@/components/runtz/vulnerability-filter"
 import { Badge } from "@/components/ui/badge"
@@ -159,7 +159,7 @@ export default function HostDetailPage() {
                     Latest scan on {formatDate(latestScan.createdAt)}
                   </CardDescription>
                 </div>
-                <CVEFixFilterSwitches />
+                <UnfixedCVEsSwitch />
               </CardHeader>
               <CardContent>
                 {scanDetail.loading ? (

--- a/frontend/src/app/app/hosts/page.tsx
+++ b/frontend/src/app/app/hosts/page.tsx
@@ -14,7 +14,7 @@ import { FirstScanEmptyState } from "@/components/runtz/scan-empty-state"
 import { usePlatform } from "@/components/runtz/platform-context"
 import { usePackageScans } from "@/components/runtz/use-package-scans"
 import {
-  CVEFixFilterSwitches,
+  UnfixedCVEsSwitch,
   useVulnerabilityFilter,
 } from "@/components/runtz/vulnerability-filter"
 import { Badge } from "@/components/ui/badge"
@@ -137,7 +137,7 @@ export default function HostsPage() {
                     Click a hostname to see the CVE list from its latest scan.
                   </CardDescription>
                 </div>
-                <CVEFixFilterSwitches />
+                <UnfixedCVEsSwitch />
               </CardHeader>
               <CardContent>
                 <Table>

--- a/frontend/src/app/app/overview/page.tsx
+++ b/frontend/src/app/app/overview/page.tsx
@@ -22,7 +22,7 @@ import { useFindingScans } from "@/components/runtz/use-finding-scans"
 import { usePackageScans } from "@/components/runtz/use-package-scans"
 import { useSCAScans } from "@/components/runtz/use-sca-scans"
 import {
-  CVEFixFilterSwitches,
+  UnfixedCVEsSwitch,
   useVulnerabilityFilter,
 } from "@/components/runtz/vulnerability-filter"
 import { Badge } from "@/components/ui/badge"
@@ -124,7 +124,7 @@ export default function OverviewPage() {
             </p>
           </div>
         </div>
-        <CVEFixFilterSwitches />
+        <UnfixedCVEsSwitch />
       </div>
 
       {error ? (

--- a/frontend/src/app/app/sca/[projectName]/page.tsx
+++ b/frontend/src/app/app/sca/[projectName]/page.tsx
@@ -18,7 +18,7 @@ import { usePlatform } from "@/components/runtz/platform-context"
 import { useScanDetail } from "@/components/runtz/use-scan-detail"
 import { useSCAScans } from "@/components/runtz/use-sca-scans"
 import {
-  CVEFixFilterSwitches,
+  UnfixedCVEsSwitch,
   useVulnerabilityFilter,
 } from "@/components/runtz/vulnerability-filter"
 import { Badge } from "@/components/ui/badge"
@@ -155,7 +155,7 @@ export default function SCAProjectPage() {
                     Latest scan on {formatDate(latestScan.createdAt)}
                   </CardDescription>
                 </div>
-                <CVEFixFilterSwitches />
+                <UnfixedCVEsSwitch />
               </CardHeader>
               <CardContent>
                 {scanDetail.loading ? (

--- a/frontend/src/app/app/sca/page.tsx
+++ b/frontend/src/app/app/sca/page.tsx
@@ -14,7 +14,7 @@ import { FirstScanEmptyState } from "@/components/runtz/scan-empty-state"
 import { usePlatform } from "@/components/runtz/platform-context"
 import { useSCAScans } from "@/components/runtz/use-sca-scans"
 import {
-  CVEFixFilterSwitches,
+  UnfixedCVEsSwitch,
   useVulnerabilityFilter,
 } from "@/components/runtz/vulnerability-filter"
 import { Badge } from "@/components/ui/badge"
@@ -127,7 +127,7 @@ export default function SCAPage() {
                     Click an app name to see the CVE list from its latest scan.
                   </CardDescription>
                 </div>
-                <CVEFixFilterSwitches />
+                <UnfixedCVEsSwitch />
               </CardHeader>
               <CardContent>
                 <Table>

--- a/frontend/src/components/runtz/package-vulnerability-explorer.tsx
+++ b/frontend/src/components/runtz/package-vulnerability-explorer.tsx
@@ -13,7 +13,10 @@ import * as React from "react"
 
 import { SeverityBadge } from "@/components/runtz/sca-components"
 import { CleanScanState } from "@/components/runtz/scan-empty-state"
-import { useVulnerabilityFilter } from "@/components/runtz/vulnerability-filter"
+import {
+  UnfixedCVEsSwitch,
+  useVulnerabilityFilter,
+} from "@/components/runtz/vulnerability-filter"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
@@ -71,50 +74,22 @@ export function PackageVulnerabilityExplorer({
     () => groupVulnerabilitiesByPackage(filteredVulnerabilities),
     [filteredVulnerabilities]
   )
+  const allGroups = React.useMemo(
+    () => groupVulnerabilitiesByPackage(vulnerabilities),
+    [vulnerabilities]
+  )
   const [selectedKey, setSelectedKey] = React.useState<string>()
   const lastTriggerRef = React.useRef<HTMLButtonElement | null>(null)
   const selectedGroup = React.useMemo(
-    () => groups.find((group) => group.key === selectedKey),
-    [groups, selectedKey]
+    () => allGroups.find((group) => group.key === selectedKey),
+    [allGroups, selectedKey]
   )
-
-  if (vulnerabilities.length === 0) {
-    return <CleanScanState />
-  }
-
-  if (groups.length === 0) {
-    return (
-      <Empty className="min-h-56 border">
-        <EmptyHeader>
-          <EmptyMedia variant="icon">
-            <ListFilterIcon />
-          </EmptyMedia>
-          <EmptyTitle>No CVEs match this filter</EmptyTitle>
-          <EmptyDescription>
-            This scan has no vulnerabilities in the selected fix category.
-          </EmptyDescription>
-        </EmptyHeader>
-        <Button variant="outline" size="sm" onClick={() => setFilter("all")}>
-          Show all CVEs
-        </Button>
-      </Empty>
-    )
-  }
-
   const context = {
     targetName,
     targetKind,
     osName,
     osVersion,
     packageManager,
-  }
-
-  function selectPackage(
-    groupKey: string,
-    event: React.MouseEvent<HTMLButtonElement>
-  ) {
-    lastTriggerRef.current = event.currentTarget
-    setSelectedKey(groupKey)
   }
 
   function handleOpenChange(open: boolean) {
@@ -125,6 +100,46 @@ export function PackageVulnerabilityExplorer({
     window.requestAnimationFrame(() => lastTriggerRef.current?.focus())
   }
 
+  if (vulnerabilities.length === 0) {
+    return <CleanScanState />
+  }
+
+  if (groups.length === 0) {
+    return (
+      <>
+        <Empty className="min-h-56 border">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <ListFilterIcon />
+            </EmptyMedia>
+            <EmptyTitle>No unfixed CVEs</EmptyTitle>
+            <EmptyDescription>
+              Every vulnerability in this scan currently has a fix available.
+              Turn off the filter to review all CVEs, and keep scanning to stay
+              current as fix availability changes.
+            </EmptyDescription>
+          </EmptyHeader>
+          <Button variant="outline" size="sm" onClick={() => setFilter("all")}>
+            Show all CVEs
+          </Button>
+        </Empty>
+        <Sheet open={Boolean(selectedGroup)} onOpenChange={handleOpenChange}>
+          {selectedGroup ? (
+            <PackageDetailSheet group={selectedGroup} context={context} />
+          ) : null}
+        </Sheet>
+      </>
+    )
+  }
+
+  function selectPackage(
+    groupKey: string,
+    event: React.MouseEvent<HTMLButtonElement>
+  ) {
+    lastTriggerRef.current = event.currentTarget
+    setSelectedKey(groupKey)
+  }
+
   return (
     <>
       <div className="mb-3 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
@@ -132,7 +147,11 @@ export function PackageVulnerabilityExplorer({
           {filteredVulnerabilities.length} occurrences consolidated into {groups.length}{" "}
           {groups.length === 1 ? "package" : "packages"}
         </span>
-        <span>Select a package to investigate and remediate</span>
+        <span>
+          {filter === "without-fix"
+            ? "No fix is available yet · keep scanning for updates"
+            : "Select a package to investigate and remediate"}
+        </span>
       </div>
 
       <div className="hidden md:block">
@@ -246,6 +265,11 @@ function PackageDetailSheet({
   group: PackageVulnerabilityGroup
   context: RemediationContext
 }) {
+  const { filter } = useVulnerabilityFilter()
+  const visibleVulnerabilities = React.useMemo(
+    () => filterVulnerabilitiesByFix(group.vulnerabilities, filter),
+    [filter, group.vulnerabilities]
+  )
   const [copyStatus, setCopyStatus] = React.useState<
     "idle" | "copied" | "error"
   >("idle")
@@ -349,22 +373,38 @@ function PackageDetailSheet({
         <Separator />
 
         <section aria-labelledby="package-cves-title">
-          <div className="mb-3">
-            <h2 id="package-cves-title" className="font-medium">
-              Package vulnerabilities
-            </h2>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Sorted by severity, with every reference received in the scan.
-            </p>
+          <div className="mb-3 flex flex-col justify-between gap-3 sm:flex-row sm:items-start">
+            <div>
+              <h2 id="package-cves-title" className="font-medium">
+                Package vulnerabilities
+              </h2>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {filter === "without-fix"
+                  ? "These CVEs don't have a fix yet. Keep scanning to stay updated as soon as one becomes available."
+                  : "Sorted by severity, with every reference received in the scan."}
+              </p>
+            </div>
+            <UnfixedCVEsSwitch />
           </div>
-          <div className="flex flex-col divide-y rounded-lg border">
-            {group.vulnerabilities.map((vulnerability) => (
-              <VulnerabilityDetail
-                key={`${group.key}-${vulnerability.id}`}
-                vulnerability={vulnerability}
-              />
-            ))}
-          </div>
+          {visibleVulnerabilities.length > 0 ? (
+            <div className="flex flex-col divide-y rounded-lg border">
+              {visibleVulnerabilities.map((vulnerability) => (
+                <VulnerabilityDetail
+                  key={`${group.key}-${vulnerability.id}`}
+                  vulnerability={vulnerability}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-lg border border-dashed px-4 py-6 text-center">
+              <p className="text-sm font-medium">No unfixed CVEs in this package</p>
+              <p className="mx-auto mt-1 max-w-lg text-xs leading-relaxed text-muted-foreground">
+                Every vulnerability in this package currently has a fix available.
+                Turn off the filter to review all CVEs, and keep scanning to stay
+                current as fix availability changes.
+              </p>
+            </div>
+          )}
         </section>
       </div>
     </SheetContent>

--- a/frontend/src/components/runtz/sca-components.tsx
+++ b/frontend/src/components/runtz/sca-components.tsx
@@ -4,7 +4,6 @@ import * as React from "react"
 import {
   ActivityIcon,
   ChartSplineIcon,
-  MinusIcon,
   PackageIcon,
   ShieldAlertIcon,
   TrendingDownIcon,
@@ -1060,7 +1059,7 @@ function VulnerabilityDelta({ delta }: { delta: number | null }) {
 
   return (
     <Badge variant="outline" aria-label="No vulnerability count change">
-      <MinusIcon data-icon="inline-start" />0
+      −
     </Badge>
   )
 }

--- a/frontend/src/components/runtz/vulnerability-filter.tsx
+++ b/frontend/src/components/runtz/vulnerability-filter.tsx
@@ -7,7 +7,7 @@ import { Switch } from "@/components/ui/switch"
 import type { CVEFixFilter } from "@/lib/dashboard"
 import { cn } from "@/lib/utils"
 
-const CVE_FIX_FILTER_STORAGE_KEY = "runtz_cve_fix_filter"
+const UNFIXED_CVES_FILTER_STORAGE_KEY = "runtz_unfixed_cves_only"
 
 type VulnerabilityFilterContextValue = {
   filter: CVEFixFilter
@@ -22,18 +22,24 @@ export function VulnerabilityFilterProvider({
 }: {
   children: React.ReactNode
 }) {
-  const [filter, setFilterState] = React.useState<CVEFixFilter>("all")
+  const [filter, setFilterState] =
+    React.useState<CVEFixFilter>("without-fix")
 
   React.useEffect(() => {
-    const stored = window.localStorage.getItem(CVE_FIX_FILTER_STORAGE_KEY)
-    if (isCVEFixFilter(stored)) {
-      setFilterState(stored)
+    const stored = window.localStorage.getItem(
+      UNFIXED_CVES_FILTER_STORAGE_KEY
+    )
+    if (stored === "false") {
+      setFilterState("all")
     }
   }, [])
 
   const setFilter = React.useCallback((nextFilter: CVEFixFilter) => {
     setFilterState(nextFilter)
-    window.localStorage.setItem(CVE_FIX_FILTER_STORAGE_KEY, nextFilter)
+    window.localStorage.setItem(
+      UNFIXED_CVES_FILTER_STORAGE_KEY,
+      String(nextFilter === "without-fix")
+    )
   }, [])
 
   const value = React.useMemo(
@@ -58,53 +64,27 @@ export function useVulnerabilityFilter() {
   return context
 }
 
-export function CVEFixFilterSwitches({ className }: { className?: string }) {
+export function UnfixedCVEsSwitch({ className }: { className?: string }) {
   const { filter, setFilter } = useVulnerabilityFilter()
-  const includesWithFix = filter !== "without-fix"
-  const includesWithoutFix = filter !== "with-fix"
+  const switchId = React.useId()
 
   return (
     <div
       className={cn(
-        "flex w-fit flex-wrap items-center gap-x-4 gap-y-2 rounded-lg border bg-muted/35 px-3 py-2",
+        "flex w-fit shrink-0 items-center gap-2 rounded-lg border bg-muted/35 px-3 py-2",
         className
       )}
-      role="group"
-      aria-label="Filter CVEs by fix availability"
     >
-      <span className="text-xs font-medium text-muted-foreground">
-        CVE filter
-      </span>
-      <div className="flex items-center gap-2">
-        <Switch
-          id="cve-filter-with-fix"
-          checked={includesWithFix}
-          disabled={includesWithFix && !includesWithoutFix}
-          onCheckedChange={(checked) =>
-            setFilter(checked ? "all" : "without-fix")
-          }
-        />
-        <Label htmlFor="cve-filter-with-fix" className="text-xs">
-          With fix
-        </Label>
-      </div>
-      <div className="flex items-center gap-2">
-        <Switch
-          id="cve-filter-without-fix"
-          checked={includesWithoutFix}
-          disabled={includesWithoutFix && !includesWithFix}
-          onCheckedChange={(checked) =>
-            setFilter(checked ? "all" : "with-fix")
-          }
-        />
-        <Label htmlFor="cve-filter-without-fix" className="text-xs">
-          No fix yet
-        </Label>
-      </div>
+      <Switch
+        id={switchId}
+        checked={filter === "without-fix"}
+        onCheckedChange={(checked) =>
+          setFilter(checked ? "without-fix" : "all")
+        }
+      />
+      <Label htmlFor={switchId} className="whitespace-nowrap text-xs">
+        Unfixed CVEs only
+      </Label>
     </div>
   )
-}
-
-function isCVEFixFilter(value: string | null): value is CVEFixFilter {
-  return value === "all" || value === "with-fix" || value === "without-fix"
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -257,6 +257,7 @@ export function clearClientState() {
   window.localStorage.removeItem("runtz_workspace_id")
   window.localStorage.removeItem("runtz_workspace_filter")
   window.localStorage.removeItem("runtz_cve_fix_filter")
+  window.localStorage.removeItem("runtz_unfixed_cves_only")
 }
 
 export async function signOut() {

--- a/frontend/src/lib/dashboard.ts
+++ b/frontend/src/lib/dashboard.ts
@@ -1,6 +1,6 @@
 import type { ScanSummary, VulnerabilityCounts } from "@/lib/api"
 
-export type CVEFixFilter = "all" | "with-fix" | "without-fix"
+export type CVEFixFilter = "all" | "without-fix"
 
 export type TrendScan = {
   id?: string
@@ -48,8 +48,7 @@ export function filterScanSummary(
     return summary
   }
 
-  const counts = filter === "with-fix" ? summary.withFix : summary.withoutFix
-  return summaryFromCounts(summary.totalDependencies, counts)
+  return summaryFromCounts(summary.totalDependencies, summary.withoutFix)
 }
 
 function summaryFromCounts(

--- a/frontend/src/lib/package-vulnerabilities.ts
+++ b/frontend/src/lib/package-vulnerabilities.ts
@@ -92,9 +92,8 @@ export function filterVulnerabilitiesByFix(
     return vulnerabilities
   }
 
-  const wantsFix = filter === "with-fix"
   return vulnerabilities.filter(
-    (vulnerability) => vulnerabilityHasFix(vulnerability) === wantsFix
+    (vulnerability) => !vulnerabilityHasFix(vulnerability)
   )
 }
 


### PR DESCRIPTION
## What does this PR do?

Replaces the two fix-availability toggles with one compact **Unfixed CVEs only** switch that is enabled by default and shared across overview, asset lists, scan results, and package details.

The package detail sheet now stays open when the filter hides every CVE and explains the current fix state clearly. Latest-scan entries render a plain dash for unchanged vulnerability totals instead of “− 0”.

## Base branch

- [x] This PR targets `dev` (or is a release promotion to `main`)

## Checklist

- [ ] `cd engine && go test ./...` passes (backend unchanged)
- [x] `cd frontend && npm run lint && npm run build` passes (if frontend changed)
- [ ] `helm lint helm/runtz` passes (chart unchanged)
- [x] No secrets, tokens or personal endpoints in the diff
- [x] Docs updated (README / site docs) if behavior changed (existing fix-filter documentation remains accurate)

## Generated by

- **Author:** Codex (GPT-5)
- **Task / prompt:** Simplify fix filtering to one default-on unfixed-CVE switch, improve package-detail/empty-state messaging, and show a dash for unchanged scan deltas.
- **How it was verified:** ESLint, production build with TypeScript, diff check, and local browser validation of default-on, off, empty-state, latest-scan delta, and package-detail interactions.
- [ ] A human reviewed the full diff and takes responsibility for it

By submitting this pull request, I agree that my contribution is provided
under the project license (BUSL-1.1) as described in CONTRIBUTING.md.
