### PR TITLE
VS Code extension docs + findings deep-link by scanId

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,9 @@ This file is the contract for anyone — human or AI coding agent (Claude, Codex
 
 The scanner CLI is **not** here — it lives in
 [runtz-dev/runtz-cli](https://github.com/runtz-dev/runtz-cli). The MCP server is
-in [runtz-dev/runtz-mcp](https://github.com/runtz-dev/runtz-mcp).
+in [runtz-dev/runtz-mcp](https://github.com/runtz-dev/runtz-mcp). The VS Code
+extension is in
+[runtz-dev/runtz-vscode-extension](https://github.com/runtz-dev/runtz-vscode-extension).
 
 ## Branch and release flow
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ The scanner CLI lives in its own repository,
 and release independently. The MCP server lives in
 [runtz-dev/runtz-mcp](https://github.com/runtz-dev/runtz-mcp).
 
+The VS Code extension lives in
+[runtz-dev/runtz-vscode-extension](https://github.com/runtz-dev/runtz-vscode-extension),
+so it can evolve and release independently. It uses the installed Runtz CLI to
+run SAST from folder context menus and SCA from supported dependency manifests,
+then surfaces the latest result in the VS Code Activity Bar.
+
 ## Current Scope
 
 Implemented:

--- a/frontend/src/app/app/sca/[projectName]/page.tsx
+++ b/frontend/src/app/app/sca/[projectName]/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import { useParams } from "next/navigation"
+import { useParams, useSearchParams } from "next/navigation"
 import { ArrowLeftIcon, RadarIcon } from "lucide-react"
 import * as React from "react"
 
@@ -45,6 +45,8 @@ export default function SCAProjectPage() {
   const { basePath } = usePlatform()
   const { filter } = useVulnerabilityFilter()
   const params = useParams<{ projectName: string }>()
+  const searchParams = useSearchParams()
+  const requestedScanId = searchParams.get("scanId")
   const projectName = React.useMemo(
     () => decodeProjectName(params.projectName),
     [params.projectName]
@@ -54,13 +56,18 @@ export default function SCAProjectPage() {
     () => filterScansByProject(scans, projectName),
     [projectName, scans]
   )
-  const latestScan = projectScans[0]
-  const latestSummary = React.useMemo(
+  const selectedScan = React.useMemo(
     () =>
-      latestScan ? filterScanSummary(latestScan.summary, filter) : undefined,
-    [filter, latestScan]
+      projectScans.find((scan) => scan.id === requestedScanId) ??
+      projectScans[0],
+    [projectScans, requestedScanId]
   )
-  const scanDetail = useScanDetail("sca", latestScan)
+  const selectedSummary = React.useMemo(
+    () =>
+      selectedScan ? filterScanSummary(selectedScan.summary, filter) : undefined,
+    [filter, selectedScan]
+  )
+  const scanDetail = useScanDetail("sca", selectedScan)
 
   return (
     <div className="flex flex-col gap-6 p-4 md:p-6">
@@ -86,7 +93,7 @@ export default function SCAProjectPage() {
               {projectName}
             </h1>
             <p className="text-sm text-muted-foreground">
-              Vulnerability results from this app&apos;s latest SCA scan.
+              Vulnerability results from the selected SCA scan.
             </p>
           </div>
         </div>
@@ -107,7 +114,7 @@ export default function SCAProjectPage() {
             <Skeleton key={index} className="h-28" />
           ))}
         </div>
-      ) : !latestScan || !latestSummary ? (
+      ) : !selectedScan || !selectedSummary ? (
         <Empty className="min-h-80 border">
           <EmptyHeader>
             <EmptyMedia variant="icon">
@@ -121,7 +128,7 @@ export default function SCAProjectPage() {
         </Empty>
       ) : (
         <>
-          <DashboardSummaryGrid summary={latestSummary}>
+          <DashboardSummaryGrid summary={selectedSummary}>
             <MetricCard
               title="Scans"
               value={projectScans.length}
@@ -129,17 +136,17 @@ export default function SCAProjectPage() {
             />
             <MetricCard
               title="Dependencies"
-              value={latestSummary.totalDependencies}
-              description="in the latest scan"
+              value={selectedSummary.totalDependencies}
+              description="in the selected scan"
             />
             <MetricCard
               title="CVEs/GHSAs"
-              value={latestSummary.vulnerabilities}
-              description="in the latest scan"
+              value={selectedSummary.vulnerabilities}
+              description="in the selected scan"
             />
             <MetricCard
               title="Critical/High"
-              value={latestSummary.critical + latestSummary.high}
+              value={selectedSummary.critical + selectedSummary.high}
               description="fix priority"
             />
           </DashboardSummaryGrid>
@@ -152,7 +159,7 @@ export default function SCAProjectPage() {
                 <div>
                   <CardTitle>Vulnerability results</CardTitle>
                   <CardDescription>
-                    Latest scan on {formatDate(latestScan.createdAt)}
+                    Selected scan on {formatDate(selectedScan.createdAt)}
                   </CardDescription>
                 </div>
                 <ShowUnfixedCVEsSwitch />

--- a/frontend/src/components/runtz/findings-target-page.tsx
+++ b/frontend/src/components/runtz/findings-target-page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import { useParams } from "next/navigation"
+import { useParams, useSearchParams } from "next/navigation"
 import { ArrowLeftIcon } from "lucide-react"
 import type { LucideIcon } from "lucide-react"
 import * as React from "react"
@@ -71,6 +71,8 @@ export function FindingsTargetPage({
 }: FindingsTargetPageProps) {
   const { basePath } = usePlatform()
   const params = useParams<{ targetName: string }>()
+  const searchParams = useSearchParams()
+  const requestedScanId = searchParams.get("scanId")
   const targetName = React.useMemo(
     () => decodeParam(params.targetName),
     [params.targetName]
@@ -80,10 +82,14 @@ export function FindingsTargetPage({
     () => filterFindingsScansByTarget(scans, targetName),
     [scans, targetName]
   )
-  const latestScan = targetScans[0]
-  const latestSummary = latestScan?.summary
-  const scanDetail = useScanDetail(scanType, latestScan)
-  const latestFindings = React.useMemo(
+  const selectedScan = React.useMemo(
+    () =>
+      targetScans.find((scan) => scan.id === requestedScanId) ?? targetScans[0],
+    [requestedScanId, targetScans]
+  )
+  const selectedSummary = selectedScan?.summary
+  const scanDetail = useScanDetail(scanType, selectedScan)
+  const selectedFindings = React.useMemo(
     () =>
       scanDetail.scan
         ? (scanDetail.scan.findings ?? []).map((finding) => ({
@@ -100,19 +106,19 @@ export function FindingsTargetPage({
   >(new Set())
   const categoryCounts = React.useMemo(() => {
     const counts: Record<string, number> = {}
-    for (const { finding } of latestFindings) {
+    for (const { finding } of selectedFindings) {
       const category = finding.category || "uncategorized"
       counts[category] = (counts[category] ?? 0) + 1
     }
     return counts
-  }, [latestFindings])
+  }, [selectedFindings])
   const visibleFindings = React.useMemo(
     () =>
-      latestFindings.filter(
+      selectedFindings.filter(
         ({ finding }) =>
           !disabledCategories.has(finding.category || "uncategorized")
       ),
-    [latestFindings, disabledCategories]
+    [selectedFindings, disabledCategories]
   )
 
   const toggleCategory = React.useCallback(
@@ -173,7 +179,7 @@ export function FindingsTargetPage({
             <Skeleton key={index} className="h-28" />
           ))}
         </div>
-      ) : !latestScan || !latestSummary ? (
+      ) : !selectedScan || !selectedSummary ? (
         <Empty className="min-h-80 border">
           <EmptyHeader>
             <EmptyMedia variant="icon">
@@ -185,7 +191,7 @@ export function FindingsTargetPage({
         </Empty>
       ) : (
         <>
-          <DashboardSummaryGrid summary={latestSummary}>
+          <DashboardSummaryGrid summary={selectedSummary}>
             <MetricCard
               title="Scans"
               value={targetScans.length}
@@ -193,17 +199,17 @@ export function FindingsTargetPage({
             />
             <MetricCard
               title={inspectedTitle}
-              value={latestSummary.totalDependencies}
-              description="in the latest scan"
+              value={selectedSummary.totalDependencies}
+              description="in the selected scan"
             />
             <MetricCard
               title="Findings"
-              value={latestSummary.vulnerabilities}
-              description="in the latest scan"
+              value={selectedSummary.vulnerabilities}
+              description="in the selected scan"
             />
             <MetricCard
               title="Critical/High"
-              value={latestSummary.critical + latestSummary.high}
+              value={selectedSummary.critical + selectedSummary.high}
               description="fix priority"
             />
           </DashboardSummaryGrid>
@@ -215,7 +221,7 @@ export function FindingsTargetPage({
               <Card>
                 <CardHeader>
                   <CardTitle>Findings found</CardTitle>
-                  <CardDescription>Loading the latest scan…</CardDescription>
+                  <CardDescription>Loading the selected scan…</CardDescription>
                 </CardHeader>
                 <CardContent>
                   <ScanDetailSkeleton />
@@ -227,12 +233,12 @@ export function FindingsTargetPage({
               <FindingsTable
                 scans={[scanDetail.scan]}
                 findings={visibleFindings}
-                scanIsClean={latestFindings.length === 0}
+                scanIsClean={selectedFindings.length === 0}
                 title="Security findings"
                 description={
                   disabledCategories.size > 0
-                    ? `Showing ${visibleFindings.length} of ${latestFindings.length} findings · Latest scan on ${formatDate(latestScan.createdAt)}`
-                    : `Latest scan on ${formatDate(latestScan.createdAt)}`
+                    ? `Showing ${visibleFindings.length} of ${selectedFindings.length} findings · Selected scan on ${formatDate(selectedScan.createdAt)}`
+                    : `Selected scan on ${formatDate(selectedScan.createdAt)}`
                 }
               />
             ) : null}
@@ -248,22 +254,22 @@ export function FindingsTargetPage({
               <Card>
                 <CardHeader>
                   <CardTitle>{targetTitle}</CardTitle>
-                  <CardDescription>{latestScan.workspaceName}</CardDescription>
+                  <CardDescription>{selectedScan.workspaceName}</CardDescription>
                 </CardHeader>
                 <CardContent className="flex flex-col gap-2 text-sm">
                   <div className="flex justify-between gap-4">
                     <span className="text-muted-foreground">Source</span>
                     <span className="truncate text-right">
-                      {latestScan.source || "-"}
+                      {selectedScan.source || "-"}
                     </span>
                   </div>
                   <div className="flex justify-between gap-4">
                     <span className="text-muted-foreground">Status</span>
-                    <span>{latestScan.status || "-"}</span>
+                    <span>{selectedScan.status || "-"}</span>
                   </div>
                   <div className="flex justify-between gap-4">
                     <span className="text-muted-foreground">Scanner</span>
-                    <span>{latestScan.scannerVersion || "-"}</span>
+                    <span>{selectedScan.scannerVersion || "-"}</span>
                   </div>
                 </CardContent>
               </Card>


### PR DESCRIPTION
## What
- Documents the new `runtz-dev/runtz-vscode-extension` repo in AGENTS.md/README, same pattern as the CLI/MCP repos.
- `FindingsTargetPage` now honors a `?scanId=` query param to open a specific historical scan instead of always defaulting to latest.

## Generated by
Claude Sonnet 5, asked to prep the vscode extension release and promote pending dev work to prod. Verified with `npm run lint` and `npm run build` in `frontend/` (no engine/helm changes in this PR).