### PR TITLE
Clarify PowerShell installation on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Until `1.0.0` ships, public builds are tagged as release candidates
 - Replaced the onboarding host-scan step with an optional VS Code extension
   setup and a scanner-agnostic completion step, so onboarding works the same
   way on Linux, macOS and Windows.
+- Clarified that the Windows CLI installation command runs in PowerShell.
 
 ## [1.0.0-rc18] - 2026-08-14
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ curl -fsSL https://runtz.dev/install.sh | bash
 runtz version
 ```
 
-Or on Windows:
+Or on Windows (PowerShell):
 
 ```powershell
 irm https://runtz.dev/install.ps1 | iex

--- a/frontend/src/app/app/onboarding/page.tsx
+++ b/frontend/src/app/app/onboarding/page.tsx
@@ -176,7 +176,7 @@ export default function OnboardingPage() {
                     className="rounded-full"
                     onClick={() => setInstallOS("windows")}
                   >
-                    Windows
+                    Windows (PowerShell)
                   </Button>
                 </div>
                 <CommandLine
@@ -344,7 +344,7 @@ function OSBadge({ os }: { os: "unix" | "windows" }) {
       ) : (
         <>
           <WindowsIcon className="size-3" />
-          <span>Windows</span>
+          <span>Windows (PowerShell)</span>
         </>
       )}
     </div>


### PR DESCRIPTION
## What does this PR do?

Clarifies that the Windows `irm` installer command must be run in PowerShell by changing the onboarding and README label to `Windows (PowerShell)`.

## Base branch

- [x] This PR targets `dev` (or is a release promotion to `main`)

## Checklist

- [ ] `cd engine && go test ./...` passes (engine unchanged)
- [x] `cd frontend && npm run lint && npm run build` passes (if frontend changed)
- [ ] `helm lint helm/runtz` passes (chart unchanged)
- [x] No secrets, tokens or personal endpoints in the diff
- [x] Docs updated (README / site docs) if behavior changed

## Generated by

- **Author:** Codex (GPT-5)
- **Task / prompt:** Label the Windows installer as PowerShell in onboarding and documentation.
- **How it was verified:** `npm run lint`; production Next.js build; `git diff --check`.
- [ ] A human reviewed the full diff and takes responsibility for it

By submitting this pull request, I agree that my contribution is provided under the project license (BUSL-1.1) as described in CONTRIBUTING.md.
