### PR TITLE
Fix checkout activation and streamline workspace creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,10 @@ self-updater and pipeline examples.
 - Workspaces, users, profiles, usage tracking and paid-plan billing.
 - In cloud, deleting a workspace removes its scans and API keys without creating
   a replacement, including after signing in again. Create another from
-  **Settings → Workspaces**; Free includes one owned workspace, with `personal`
-  as an editable default name. Pages without any workspace link to this form.
+  **Settings → Workspaces → New workspace**, using the button in the
+  **Your workspaces** header. Free includes one owned workspace, with `personal`
+  as an editable default name in the creation dialog. Pages without any workspace
+  link to these settings.
 - Docker Compose and Helm deployments for self-hosting.
 - OpenTelemetry traces and metrics for the engine and frontend.
 

--- a/engine/internal/api/billing.go
+++ b/engine/internal/api/billing.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -211,8 +212,12 @@ func (s *Server) handleCreateCheckoutSession(w http.ResponseWriter, r *http.Requ
 	}
 
 	now := time.Now().UTC()
+	// A completion webhook may arrive before this write. Never reset a
+	// confirmed checkout to pending when the create request finishes later.
 	record := bson.M{
-		"$set": bson.M{
+		"$setOnInsert": bson.M{
+			"_id":                        bson.NewObjectID(),
+			"created_at":                 now,
 			"email":                      email,
 			"plan":                       plan,
 			"deployment_mode":            deploymentMode,
@@ -221,23 +226,24 @@ func (s *Server) handleCreateCheckoutSession(w http.ResponseWriter, r *http.Requ
 			"stripe_price_id":            priceID,
 			"updated_at":                 now,
 		},
-		"$setOnInsert": bson.M{
-			"_id":        bson.NewObjectID(),
-			"created_at": now,
-		},
 	}
 	if hasUser {
-		record["$set"].(bson.M)["user_id"] = user.ID
+		record["$setOnInsert"].(bson.M)["user_id"] = user.ID
 	}
 	if strings.TrimSpace(request.InstallationID) != "" {
-		record["$set"].(bson.M)["installation_id"] = strings.TrimSpace(request.InstallationID)
+		record["$setOnInsert"].(bson.M)["installation_id"] = strings.TrimSpace(request.InstallationID)
 	}
-	_, _ = s.billingSubscriptions.UpdateOne(
+	_, err := s.billingSubscriptions.UpdateOne(
 		r.Context(),
 		bson.M{"stripe_checkout_session_id": session.ID},
 		record,
 		options.UpdateOne().SetUpsert(true),
 	)
+	if err != nil {
+		slog.Error("store pending checkout", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to store checkout session")
+		return
+	}
 
 	writeJSON(w, http.StatusOK, map[string]string{
 		"id":  session.ID,
@@ -311,7 +317,14 @@ func (s *Server) handleGetCheckoutSessionStatus(w http.ResponseWriter, r *http.R
 
 	subscription, err := s.ensureCheckoutSessionStored(r.Context(), sessionID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "checkout session not found")
+		var stripeErr stripeHTTPError
+		switch {
+		case errors.Is(err, mongo.ErrNoDocuments), errors.As(err, &stripeErr) && stripeErr.StatusCode == http.StatusNotFound:
+			writeError(w, http.StatusNotFound, "checkout session not found")
+		default:
+			slog.Error("synchronize checkout", "error", err)
+			writeError(w, http.StatusBadGateway, "failed to confirm subscription; please try again")
+		}
 		return
 	}
 
@@ -364,6 +377,7 @@ func (s *Server) handleStripeWebhook(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := s.storeCheckoutSession(r.Context(), session); err != nil {
+			slog.Error("synchronize checkout webhook", "event_id", event.ID, "error", err)
 			writeError(w, http.StatusInternalServerError, "failed to store checkout session")
 			return
 		}
@@ -373,7 +387,21 @@ func (s *Server) handleStripeWebhook(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, "invalid subscription object")
 			return
 		}
+		// Deliveries can arrive out of order. Read Stripe's current state so an
+		// older created/updated event cannot undo a payment or cancellation.
+		if strings.TrimSpace(subscription.ID) == "" {
+			writeError(w, http.StatusBadRequest, "stripe subscription id is required")
+			return
+		}
+		var latest stripeSubscription
+		if err := s.stripeGet(r.Context(), "/subscriptions/"+url.PathEscape(subscription.ID), nil, &latest); err != nil {
+			slog.Error("refresh subscription webhook", "event_id", event.ID, "error", err)
+			writeError(w, http.StatusBadGateway, "failed to retrieve subscription")
+			return
+		}
+		subscription = latest
 		if err := s.storeStripeSubscription(r.Context(), subscription, "", "", ""); err != nil {
+			slog.Error("synchronize subscription webhook", "event_id", event.ID, "error", err)
 			writeError(w, http.StatusInternalServerError, "failed to store subscription")
 			return
 		}
@@ -388,11 +416,17 @@ func (s *Server) ensureCheckoutSessionStored(ctx context.Context, sessionID stri
 	if err == nil && subscriptionStatusActive(existing.Status) {
 		return existing, nil
 	}
+	if err != nil && !errors.Is(err, mongo.ErrNoDocuments) {
+		return BillingSubscription{}, err
+	}
 
 	if strings.TrimSpace(s.cfg.StripeSecretKey) != "" {
 		var session stripeCheckoutSession
-		if stripeErr := s.stripeGet(ctx, "/checkout/sessions/"+url.PathEscape(sessionID), nil, &session); stripeErr == nil {
-			_ = s.storeCheckoutSession(ctx, session)
+		if err := s.stripeGet(ctx, "/checkout/sessions/"+url.PathEscape(sessionID), nil, &session); err != nil {
+			return BillingSubscription{}, err
+		}
+		if err := s.storeCheckoutSession(ctx, session); err != nil {
+			return BillingSubscription{}, err
 		}
 	}
 
@@ -406,14 +440,16 @@ func (s *Server) ensureCheckoutSessionStored(ctx context.Context, sessionID stri
 func (s *Server) storeCheckoutSession(ctx context.Context, session stripeCheckoutSession) error {
 	plan := normalizePlan(session.Metadata["plan"])
 	deploymentMode := normalizeHostingMode(session.Metadata["deployment_mode"])
-	userID, _ := bson.ObjectIDFromHex(strings.TrimSpace(session.Metadata["user_id"]))
+	userIDValue := firstNonEmpty(session.Metadata["user_id"], session.ClientReference)
+	userID, _ := bson.ObjectIDFromHex(strings.TrimSpace(userIDValue))
 	email := strings.ToLower(strings.TrimSpace(session.CustomerDetails.Email))
 
 	if session.Subscription != "" {
 		var subscription stripeSubscription
-		if err := s.stripeGet(ctx, "/subscriptions/"+url.PathEscape(session.Subscription), nil, &subscription); err == nil {
-			return s.storeStripeSubscription(ctx, subscription, session.ID, email, userID.Hex())
+		if err := s.stripeGet(ctx, "/subscriptions/"+url.PathEscape(session.Subscription), nil, &subscription); err != nil {
+			return err
 		}
+		return s.storeStripeSubscription(ctx, subscription, session.ID, email, userIDValue)
 	}
 
 	now := time.Now().UTC()
@@ -421,11 +457,14 @@ func (s *Server) storeCheckoutSession(ctx context.Context, session stripeCheckou
 		"plan":                       plan,
 		"deployment_mode":            deploymentMode,
 		"status":                     firstNonEmpty(session.Status, "checkout_complete"),
-		"email":                      email,
-		"stripe_customer_id":         session.Customer,
-		"stripe_subscription_id":     session.Subscription,
 		"stripe_checkout_session_id": session.ID,
 		"updated_at":                 now,
+	}
+	if email != "" {
+		set["email"] = email
+	}
+	if session.Customer != "" {
+		set["stripe_customer_id"] = session.Customer
 	}
 	if !userID.IsZero() {
 		set["user_id"] = userID
@@ -434,17 +473,25 @@ func (s *Server) storeCheckoutSession(ctx context.Context, session stripeCheckou
 		set["installation_id"] = installationID
 	}
 
-	_, err := s.billingSubscriptions.UpdateOne(ctx, bson.M{"stripe_checkout_session_id": session.ID}, bson.M{
+	_, err := s.billingSubscriptions.UpdateOne(ctx, pendingCheckoutFilter(session.ID), bson.M{
 		"$set": set,
 		"$setOnInsert": bson.M{
 			"_id":        bson.NewObjectID(),
 			"created_at": now,
 		},
 	}, options.UpdateOne().SetUpsert(true))
+	// A concurrent confirmation already linked this checkout. Do not replace
+	// its subscription status with an earlier open/expired checkout snapshot.
+	if mongo.IsDuplicateKeyError(err) {
+		return nil
+	}
 	return err
 }
 
 func (s *Server) storeStripeSubscription(ctx context.Context, subscription stripeSubscription, checkoutSessionID, email, userIDValue string) error {
+	if strings.TrimSpace(subscription.ID) == "" {
+		return errors.New("stripe subscription id is required")
+	}
 	plan, deploymentMode, priceID := s.planFromStripeSubscription(subscription)
 	userID, _ := bson.ObjectIDFromHex(strings.TrimSpace(firstNonEmpty(userIDValue, subscription.Metadata["user_id"])))
 	installationID := strings.TrimSpace(subscription.Metadata["installation_id"])
@@ -476,11 +523,20 @@ func (s *Server) storeStripeSubscription(ctx context.Context, subscription strip
 		set["current_period_end"] = time.Unix(periodEnd, 0).UTC()
 	}
 
-	filter := bson.M{"stripe_subscription_id": subscription.ID}
-	if subscription.ID == "" && checkoutSessionID != "" {
-		filter = bson.M{"stripe_checkout_session_id": checkoutSessionID}
+	if checkoutSessionID != "" {
+		// Promote the original checkout in place. A subscription webhook can
+		// win this race and create its own row, in which case reconcile below.
+		result, err := s.billingSubscriptions.UpdateOne(ctx, pendingCheckoutFilter(checkoutSessionID), bson.M{"$set": set})
+		if err != nil && !mongo.IsDuplicateKeyError(err) {
+			return err
+		}
+		if err == nil && result.MatchedCount > 0 {
+			return nil
+		}
 	}
 
+	filter := bson.M{"stripe_subscription_id": subscription.ID}
+	delete(set, "stripe_checkout_session_id")
 	_, err := s.billingSubscriptions.UpdateOne(ctx, filter, bson.M{
 		"$set": set,
 		"$setOnInsert": bson.M{
@@ -488,7 +544,29 @@ func (s *Server) storeStripeSubscription(ctx context.Context, subscription strip
 			"created_at": now,
 		},
 	}, options.UpdateOne().SetUpsert(true))
+	if mongo.IsDuplicateKeyError(err) {
+		// Another delivery inserted the same subscription concurrently.
+		_, err = s.billingSubscriptions.UpdateOne(ctx, filter, bson.M{"$set": set})
+	}
+	if err != nil || checkoutSessionID == "" {
+		return err
+	}
+
+	// The canonical subscription now has the confirmed checkout's identity
+	// and billing data. Remove only an unlinked placeholder before assigning
+	// its unique checkout ID. Retrying after either write is safe.
+	if _, err := s.billingSubscriptions.DeleteOne(ctx, pendingCheckoutFilter(checkoutSessionID)); err != nil {
+		return err
+	}
+	_, err = s.billingSubscriptions.UpdateOne(ctx, filter, bson.M{"$set": bson.M{"stripe_checkout_session_id": checkoutSessionID}})
 	return err
+}
+
+func pendingCheckoutFilter(sessionID string) bson.M {
+	return bson.M{
+		"stripe_checkout_session_id": sessionID,
+		"stripe_subscription_id":     bson.M{"$in": []any{nil, ""}},
+	}
 }
 
 func (s *Server) createCentralCheckoutSession(ctx context.Context, checkout createCheckoutRequest) (stripeCheckoutSession, error) {

--- a/engine/internal/api/billing.go
+++ b/engine/internal/api/billing.go
@@ -329,6 +329,10 @@ func (s *Server) handleGetCheckoutSessionStatus(w http.ResponseWriter, r *http.R
 	}
 
 	response := serializeBillingSubscription(subscription, false)
+	if subscription.DeploymentMode == hostingCloud {
+		user, signedIn := s.optionalUserFromSession(r)
+		response["accountMatches"] = signedIn && billingSubscriptionBelongsToUser(subscription, user)
+	}
 	if subscription.DeploymentMode == hostingSelfHosted && subscriptionStatusActive(subscription.Status) {
 		licenseKey, generated, err := s.ensureLicenseKey(r.Context(), subscription)
 		if err != nil {
@@ -343,6 +347,16 @@ func (s *Server) handleGetCheckoutSessionStatus(w http.ResponseWriter, r *http.R
 	}
 
 	writeJSON(w, http.StatusOK, response)
+}
+
+func billingSubscriptionBelongsToUser(subscription BillingSubscription, user User) bool {
+	// Once linked, the account ID is authoritative. A matching billing email
+	// must not make a purchase owned by another account look activated here.
+	if !subscription.UserID.IsZero() {
+		return subscription.UserID == user.ID
+	}
+	email := strings.TrimSpace(subscription.Email)
+	return email != "" && strings.EqualFold(email, strings.TrimSpace(user.Email))
 }
 
 func (s *Server) handleStripeWebhook(w http.ResponseWriter, r *http.Request) {

--- a/engine/internal/api/billing_integration_test.go
+++ b/engine/internal/api/billing_integration_test.go
@@ -275,3 +275,63 @@ func TestBillingWebhookUsesCurrentSubscription(t *testing.T) {
 		})
 	}
 }
+
+func TestBillingCheckoutAccountMatch(t *testing.T) {
+	s, ctx := billingTestServer(t)
+	owner, session, sub := billingFixtures()
+	sub.Metadata["plan"] = planEnterprise
+	if err := s.storeStripeSubscription(ctx, sub, session.ID, owner.Email, owner.ID.Hex()); err != nil {
+		t.Fatal(err)
+	}
+	other := User{ID: bson.NewObjectID(), Email: "other@example.com"}
+	for _, user := range []User{owner, other} {
+		user.Username = user.ID.Hex()
+		if _, err := s.users.InsertOne(ctx, user); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// The other account is already paid: that alone must never count as
+	// activation of the owner's Enterprise checkout.
+	otherSub := stripeSubscription{ID: "sub_other_pro", Status: "active", Metadata: map[string]string{"plan": planPro, "deployment_mode": hostingCloud, "user_id": other.ID.Hex()}}
+	if err := s.storeStripeSubscription(ctx, otherSub, "", other.Email, other.ID.Hex()); err != nil {
+		t.Fatal(err)
+	}
+	if ent := s.cloudEntitlement(ctx, &other); ent.Plan != planPro {
+		t.Fatalf("other account plan = %s", ent.Plan)
+	}
+	for _, tc := range []struct {
+		name    string
+		user    *User
+		matches bool
+	}{
+		{"owner", &owner, true},
+		{"different_paid_account", &other, false},
+		{"anonymous", nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/api/v1/billing/checkout-session/"+session.ID, nil).WithContext(ctx)
+			if tc.user != nil {
+				token, err := s.issueSession(ctx, *tc.user, r)
+				if err != nil {
+					t.Fatal(err)
+				}
+				r.AddCookie(&http.Cookie{Name: sessionCookieName, Value: token})
+			}
+			w := httptest.NewRecorder()
+			s.Handler().ServeHTTP(w, r)
+			if w.Code != http.StatusOK {
+				t.Fatalf("HTTP %d: %s", w.Code, w.Body.String())
+			}
+			var response struct {
+				Plan           string `json:"plan"`
+				AccountMatches *bool  `json:"accountMatches"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+				t.Fatal(err)
+			}
+			if response.Plan != planEnterprise || response.AccountMatches == nil || *response.AccountMatches != tc.matches {
+				t.Fatalf("unexpected checkout response: %s", w.Body.String())
+			}
+		})
+	}
+}

--- a/engine/internal/api/billing_integration_test.go
+++ b/engine/internal/api/billing_integration_test.go
@@ -1,0 +1,277 @@
+package api
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/runtz-dev/runtz/engine/internal/config"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func billingTestServer(t *testing.T) (*Server, context.Context) {
+	t.Helper()
+	uri := os.Getenv("RUNTZ_TEST_MONGO_URI")
+	if uri == "" {
+		t.Skip("set RUNTZ_TEST_MONGO_URI to run MongoDB integration tests")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	s, err := New(ctx, config.Config{DeploymentMode: hostingCloud, MongoURI: uri, MongoDatabase: "runtz_test_" + bson.NewObjectID().Hex(), StripeSecretKey: "sk_test_fixture"})
+	if err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		defer cancel()
+		defer s.Close(context.Background())
+		if err := s.db.Drop(context.Background()); err != nil {
+			t.Error(err)
+		}
+	})
+	return s, ctx
+}
+
+type billingTestTransport func(*http.Request) (*http.Response, error)
+
+func (f billingTestTransport) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func mockBillingStripe(t *testing.T, session stripeCheckoutSession, sub stripeSubscription, failPath string) {
+	t.Helper()
+	original := http.DefaultTransport
+	http.DefaultTransport = billingTestTransport(func(r *http.Request) (*http.Response, error) {
+		status := http.StatusOK
+		var payload any
+		switch r.URL.Path {
+		case "/v1/checkout/sessions/" + session.ID:
+			payload = session
+		case "/v1/subscriptions/" + sub.ID:
+			payload = sub
+		default:
+			t.Errorf("unexpected Stripe request: %s", r.URL.Path)
+			status = http.StatusNotFound
+		}
+		if r.URL.Path == failPath {
+			status = http.StatusServiceUnavailable
+		}
+		body, _ := json.Marshal(payload)
+		return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader(string(body))), Header: http.Header{}}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = original })
+}
+
+func billingFixtures() (User, stripeCheckoutSession, stripeSubscription) {
+	user := User{ID: bson.NewObjectID(), Email: "billing@example.com"}
+	metadata := map[string]string{"plan": planPro, "deployment_mode": hostingCloud, "user_id": user.ID.Hex()}
+	session := stripeCheckoutSession{ID: "cs_test_completed", Subscription: "sub_test_paid", Customer: "cus_test", Status: "complete", PaymentStatus: "paid", Metadata: metadata}
+	session.CustomerDetails.Email = user.Email
+	sub := stripeSubscription{ID: session.Subscription, Customer: session.Customer, Status: "active", Metadata: metadata, CurrentPeriodEnd: time.Now().Add(30 * 24 * time.Hour).Unix()}
+	return user, session, sub
+}
+
+func insertPendingCheckout(t *testing.T, s *Server, ctx context.Context, user User, session stripeCheckoutSession) bson.ObjectID {
+	t.Helper()
+	id := bson.NewObjectID()
+	_, err := s.billingSubscriptions.InsertOne(ctx, bson.M{"_id": id, "stripe_checkout_session_id": session.ID, "user_id": user.ID, "email": user.Email, "plan": planPro, "deployment_mode": hostingCloud, "status": "checkout_pending"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+func TestBillingCheckoutReconciliation(t *testing.T) {
+	for _, order := range []string{"checkout_first", "subscription_first", "concurrent"} {
+		t.Run(order, func(t *testing.T) {
+			s, ctx := billingTestServer(t)
+			user, session, sub := billingFixtures()
+			mockBillingStripe(t, session, sub, "")
+			pendingID := insertPendingCheckout(t, s, ctx, user, session)
+			saveSubscription := func() error { return s.storeStripeSubscription(ctx, sub, "", "", "") }
+			saveCheckout := func() error { return s.storeCheckoutSession(ctx, session) }
+			if order == "subscription_first" {
+				if err := saveSubscription(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if order == "concurrent" {
+				var wg sync.WaitGroup
+				for i := 0; i < 12; i++ {
+					wg.Add(1)
+					go func(i int) {
+						defer wg.Done()
+						var err error
+						if i%2 == 0 {
+							err = saveSubscription()
+						} else {
+							err = saveCheckout()
+						}
+						if err != nil {
+							t.Error(err)
+						}
+					}(i)
+				}
+				wg.Wait()
+			}
+			for i := 0; i < 3; i++ {
+				if err := saveCheckout(); err != nil {
+					t.Fatal(err)
+				}
+				if err := saveSubscription(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			stored, err := s.ensureCheckoutSessionStored(ctx, session.ID)
+			if err != nil || stored.Status != "active" || stored.UserID != user.ID || stored.Email != user.Email {
+				t.Fatalf("confirmed checkout: %+v, %v", stored, err)
+			}
+			if order == "checkout_first" && stored.ID != pendingID {
+				t.Fatal("checkout was not promoted in place")
+			}
+			count, err := s.billingSubscriptions.CountDocuments(ctx, bson.M{})
+			if err != nil || count != 1 {
+				t.Fatalf("billing rows = %d, err=%v", count, err)
+			}
+			if ent := s.cloudEntitlement(ctx, &user); ent.Plan != planPro || ent.Status != "active" {
+				t.Fatalf("entitlement = %+v", ent)
+			}
+			// An old checkout response must not overwrite the active subscription.
+			stale := session
+			stale.Subscription, stale.Status = "", "open"
+			if err := s.storeCheckoutSession(ctx, stale); err != nil {
+				t.Fatal(err)
+			}
+			if ent := s.cloudEntitlement(ctx, &user); ent.Plan != planPro {
+				t.Fatal("stale checkout downgraded user")
+			}
+			// Normal subscription cancellation must still revoke entitlement.
+			sub.Status = "canceled"
+			if err := s.storeStripeSubscription(ctx, sub, "", "", ""); err != nil {
+				t.Fatal(err)
+			}
+			if ent := s.cloudEntitlement(ctx, &user); ent.Plan != planFree {
+				t.Fatal("canceled subscription retained Pro")
+			}
+		})
+	}
+}
+
+func TestBillingCheckoutSyncFailures(t *testing.T) {
+	for _, failure := range []string{"checkout_api", "subscription_api", "database"} {
+		t.Run(failure, func(t *testing.T) {
+			s, ctx := billingTestServer(t)
+			user, session, sub := billingFixtures()
+			insertPendingCheckout(t, s, ctx, user, session)
+			failPath := ""
+			if failure == "checkout_api" {
+				failPath = "/v1/checkout/sessions/" + session.ID
+			}
+			if failure == "subscription_api" {
+				failPath = "/v1/subscriptions/" + sub.ID
+			}
+			mockBillingStripe(t, session, sub, failPath)
+			if failure == "database" {
+				err := s.db.RunCommand(ctx, bson.D{{Key: "collMod", Value: "billing_subscriptions"}, {Key: "validator", Value: bson.M{"status": bson.M{"$ne": "active"}}}}).Err()
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			w := httptest.NewRecorder()
+			s.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/billing/checkout-session/"+session.ID, nil).WithContext(ctx))
+			if w.Code != http.StatusBadGateway {
+				t.Fatalf("HTTP %d: %s", w.Code, w.Body.String())
+			}
+			if ent := s.cloudEntitlement(ctx, &user); ent.Plan != planFree {
+				t.Fatal("failed synchronization granted Pro")
+			}
+		})
+	}
+}
+
+func TestBillingOpenCheckoutsAndSubscriptionIdentity(t *testing.T) {
+	s, ctx := billingTestServer(t)
+	user, session, sub := billingFixtures()
+	mockBillingStripe(t, session, sub, "")
+	for _, id := range []string{"cs_open_one", "cs_open_two"} {
+		if err := s.storeCheckoutSession(ctx, stripeCheckoutSession{ID: id, Status: "open"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A missing session user_id must not mask the subscription metadata with
+	// a zero ObjectID string (000000000000000000000000).
+	session.Metadata = map[string]string{"plan": planPro, "deployment_mode": hostingCloud}
+	if err := s.storeCheckoutSession(ctx, session); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := s.ensureCheckoutSessionStored(ctx, session.ID)
+	if err != nil || stored.UserID != user.ID {
+		t.Fatalf("identity lost: %+v, %v", stored, err)
+	}
+}
+
+func TestBillingCompletionBeforeCheckoutCreateReturns(t *testing.T) {
+	s, ctx := billingTestServer(t)
+	user, session, sub := billingFixtures()
+	s.cfg.PublicURL = "https://billing.example.com"
+	s.cfg.StripePriceProCloud = "price_test_pro"
+	original := http.DefaultTransport
+	http.DefaultTransport = billingTestTransport(func(r *http.Request) (*http.Response, error) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/checkout/sessions" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		// Simulate a webhook finishing while the original API request is open.
+		if err := s.storeStripeSubscription(ctx, sub, session.ID, user.Email, user.ID.Hex()); err != nil {
+			t.Fatal(err)
+		}
+		body, _ := json.Marshal(session)
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(string(body))), Header: http.Header{}}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = original })
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/v1/billing/checkout", strings.NewReader(`{"plan":"pro","deploymentMode":"cloud"}`)).WithContext(ctx))
+	if w.Code != http.StatusOK {
+		t.Fatalf("HTTP %d: %s", w.Code, w.Body.String())
+	}
+	stored, err := s.ensureCheckoutSessionStored(ctx, session.ID)
+	if err != nil || stored.Status != "active" || stored.UserID != user.ID {
+		t.Fatalf("create request overwrote confirmed subscription: %+v, %v", stored, err)
+	}
+}
+
+func TestBillingWebhookUsesCurrentSubscription(t *testing.T) {
+	for _, currentStatus := range []string{"active", "canceled"} {
+		t.Run(currentStatus, func(t *testing.T) {
+			s, ctx := billingTestServer(t)
+			user, session, sub := billingFixtures()
+			s.cfg.StripeWebhookSecret = "whsec_fixture"
+			stale := sub
+			stale.Status = "incomplete"
+			sub.Status = currentStatus
+			mockBillingStripe(t, session, sub, "")
+			body, _ := json.Marshal(map[string]any{"id": "evt_fixture", "type": "customer.subscription.created", "data": map[string]any{"object": stale}})
+			timestamp := time.Now().Unix()
+			mac := hmac.New(sha256.New, []byte(s.cfg.StripeWebhookSecret))
+			fmt.Fprintf(mac, "%d.%s", timestamp, body)
+			r := httptest.NewRequest(http.MethodPost, "/api/v1/billing/webhook", strings.NewReader(string(body))).WithContext(ctx)
+			r.Header.Set("Stripe-Signature", fmt.Sprintf("t=%d,v1=%s", timestamp, hex.EncodeToString(mac.Sum(nil))))
+			w := httptest.NewRecorder()
+			s.Handler().ServeHTTP(w, r)
+			if w.Code != http.StatusOK {
+				t.Fatalf("HTTP %d: %s", w.Code, w.Body.String())
+			}
+			stored, err := s.findBillingSubscriptionForUser(ctx, user)
+			if err != nil || stored.Status != currentStatus {
+				t.Fatalf("stale event won: %+v, %v", stored, err)
+			}
+		})
+	}
+}

--- a/engine/internal/api/billing_test.go
+++ b/engine/internal/api/billing_test.go
@@ -8,7 +8,30 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
+
+func TestBillingSubscriptionAccountIdentity(t *testing.T) {
+	user := User{ID: bson.NewObjectID(), Email: "owner@example.com"}
+	for _, tc := range []struct {
+		name    string
+		sub     BillingSubscription
+		matches bool
+	}{
+		{"linked_account", BillingSubscription{UserID: user.ID, Email: "billing@example.com"}, true},
+		{"different_id_same_email", BillingSubscription{UserID: bson.NewObjectID(), Email: user.Email}, false},
+		{"unlinked_matching_email", BillingSubscription{Email: " OWNER@example.com "}, true},
+		{"unlinked_other_email", BillingSubscription{Email: "other@example.com"}, false},
+		{"missing_identity", BillingSubscription{}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := billingSubscriptionBelongsToUser(tc.sub, user); got != tc.matches {
+				t.Fatalf("account match = %v, want %v", got, tc.matches)
+			}
+		})
+	}
+}
 
 func TestVerifyStripeSignature(t *testing.T) {
 	payload := []byte(`{"id":"evt_test"}`)

--- a/frontend/src/app/app/settings/page.tsx
+++ b/frontend/src/app/app/settings/page.tsx
@@ -1238,7 +1238,7 @@ type BillingStatusResponse = {
 }
 
 function BillingPanel() {
-  const { deploymentMode, entitlement } = useWorkspace()
+  const { deploymentMode, entitlement, refreshEntitlement } = useWorkspace()
   const [status, setStatus] = React.useState<BillingStatusResponse | null>(null)
   const [message, setMessage] = React.useState("")
   const [error, setError] = React.useState("")
@@ -1248,6 +1248,7 @@ function BillingPanel() {
   const loadStatus = React.useCallback(async () => {
     const response = await apiRequest<BillingStatusResponse>("/api/v1/billing/status")
     setStatus(response)
+    return response
   }, [])
 
   React.useEffect(() => {
@@ -1271,7 +1272,8 @@ function BillingPanel() {
       method: "POST",
       body: { sessionId },
     })
-      .then(() => {
+      .then(async () => {
+        await refreshEntitlement()
         setMessage("License activated automatically.")
         window.history.replaceState(null, "", "/app/settings?tab=billing")
         return loadStatus()
@@ -1282,33 +1284,59 @@ function BillingPanel() {
         )
       })
       .finally(() => setPending(false))
-  }, [loadStatus])
+  }, [loadStatus, refreshEntitlement])
 
   React.useEffect(() => {
     const sessionId = new URLSearchParams(window.location.search).get(
       "billing_checkout_session"
     )
-    if (!sessionId || activatedSessionRef.current === sessionId) {
+    if (!sessionId) {
       return
     }
-    activatedSessionRef.current = sessionId
 
+    let cancelled = false
     setPending(true)
     setError("")
     setMessage("Confirming subscription...")
-    apiRequest(`/api/v1/billing/checkout-session/${encodeURIComponent(sessionId)}`)
-      .then(() => {
-        setMessage("Subscription activated.")
-        window.history.replaceState(null, "", "/app/settings?tab=billing")
-        return loadStatus()
-      })
-      .catch((error) => {
-        setError(
-          error instanceof Error ? error.message : "Failed to confirm subscription"
-        )
-      })
-      .finally(() => setPending(false))
-  }, [loadStatus])
+    async function confirmSubscription() {
+      try {
+        for (let attempt = 0; attempt < 10 && !cancelled; attempt++) {
+          const checkout = await apiRequest<{ status: string }>(
+            `/api/v1/billing/checkout-session/${encodeURIComponent(sessionId!)}`
+          )
+          if (cancelled) return
+          if (checkout.status === "active" || checkout.status === "trialing") {
+            const billing = await loadStatus()
+            if (cancelled) return
+            if (billing.entitlement.plan === "free") {
+              throw new Error("The subscription was confirmed, but is not linked to this account. Please contact support.")
+            }
+            await refreshEntitlement()
+            if (cancelled) return
+            setMessage("Subscription activated.")
+            window.history.replaceState(null, "", "/app/settings?tab=billing")
+            return
+          }
+          if (checkout.status === "expired" || checkout.status === "canceled") {
+            throw new Error("This checkout did not activate a subscription.")
+          }
+          if (attempt < 9) await new Promise((resolve) => setTimeout(resolve, 2000))
+        }
+        if (!cancelled) {
+          setMessage("Payment confirmation is still pending. Refresh this page in a moment to check again.")
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setMessage("")
+          setError(error instanceof Error ? error.message : "Failed to confirm subscription")
+        }
+      } finally {
+        if (!cancelled) setPending(false)
+      }
+    }
+    void confirmSubscription()
+    return () => { cancelled = true }
+  }, [loadStatus, refreshEntitlement])
 
   async function startCheckout(plan: "pro" | "enterprise") {
     setError("")

--- a/frontend/src/app/app/settings/page.tsx
+++ b/frontend/src/app/app/settings/page.tsx
@@ -36,6 +36,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  DialogTrigger,
 } from "@/components/ui/dialog"
 import {
   Field,
@@ -365,6 +366,7 @@ function CloudWorkspacesPanel() {
   const [name, setName] = React.useState("personal")
   const [pending, setPending] = React.useState(false)
   const [error, setError] = React.useState("")
+  const [createOpen, setCreateOpen] = React.useState(false)
   const ownedWorkspaceCount = workspaces.filter((workspace) => workspace.createdBy === currentUser.id).length
   const workspaceLimit = entitlement.plan === "free" ? 1 : entitlement.plan === "pro" ? 5 : Infinity
   const canCreateWorkspace = ownedWorkspaceCount < workspaceLimit
@@ -380,6 +382,7 @@ function CloudWorkspacesPanel() {
       })
       await refreshWorkspaces()
       setName("personal")
+      setCreateOpen(false)
     } catch (error) {
       setError(error instanceof Error ? error.message : "Failed to create workspace")
     } finally {
@@ -393,116 +396,131 @@ function CloudWorkspacesPanel() {
 
   return (
     <div className="flex flex-col gap-6">
-      {canCreateWorkspace ? (
+      <Dialog open={createOpen} onOpenChange={(open) => {
+        if (pending) return
+        setCreateOpen(open)
+        if (open) {
+          setError("")
+          setName("personal")
+        }
+      }}>
         <Card>
           <CardHeader>
-            <CardTitle>New workspace</CardTitle>
-            <CardDescription>
-              {entitlement.plan === "free"
-                ? "Your Free plan includes one workspace. Use the default name or choose your own."
-                : "Create a workspace to organize your scans."}
-            </CardDescription>
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <CardTitle>Your workspaces</CardTitle>
+                <CardDescription>
+                  Manage the workspaces you own or have access to.
+                </CardDescription>
+              </div>
+              <div className="flex flex-wrap items-center gap-3 sm:shrink-0">
+                <Badge variant={canShareWorkspace ? "secondary" : "outline"}>
+                  Current plan: {planLabel(entitlement.plan)}
+                </Badge>
+                {canCreateWorkspace ? (
+                  <DialogTrigger render={<Button variant="outline" size="sm" className="h-10 sm:h-8" />}>
+                    <PlusIcon data-icon="inline-start" />
+                    New workspace
+                  </DialogTrigger>
+                ) : null}
+              </div>
+            </div>
           </CardHeader>
           <CardContent>
-            <form onSubmit={createWorkspace} className="max-w-sm">
-              <FieldGroup>
-                <Field data-invalid={Boolean(error)}>
-                  <FieldLabel htmlFor="cloud-workspace-name">Workspace name</FieldLabel>
-                  <Input
-                    id="cloud-workspace-name"
-                    value={name}
-                    placeholder="personal"
-                    onChange={(event) => setName(event.target.value)}
-                    disabled={pending}
-                    aria-invalid={Boolean(error)}
-                    aria-describedby={error ? "cloud-workspace-error" : undefined}
-                  />
-                  {error ? <FieldError id="cloud-workspace-error" role="alert">{error}</FieldError> : null}
-                </Field>
-                <Button type="submit" disabled={pending}>
-                  <PlusIcon data-icon="inline-start" />
-                  {pending ? "Creating workspace…" : "Create workspace"}
-                </Button>
-              </FieldGroup>
-            </form>
+            {workspaces.length === 0 ? (
+              <Empty>
+                <EmptyHeader>
+                  <EmptyTitle>No workspaces yet</EmptyTitle>
+                  <EmptyDescription>Select New workspace to organize your scans and get started.</EmptyDescription>
+                </EmptyHeader>
+              </Empty>
+            ) : <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Slug</TableHead>
+                    <TableHead>Type</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {workspaces.map((workspace) => {
+                    const isOwner = workspace.createdBy === currentUser.id
+
+                    return (
+                      <TableRow key={workspace.id}>
+                        <TableCell className="font-medium">{workspace.name}</TableCell>
+                        <TableCell>{workspace.slug}</TableCell>
+                        <TableCell>
+                          <Badge variant="outline">{isOwner ? "Owner" : "Shared"}</Badge>
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex justify-end gap-2">
+                            {isOwner ? (
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => setShareUpgradeOpen(true)}
+                              >
+                                <Share2Icon data-icon="inline-start" />
+                                Share
+                              </Button>
+                            ) : null}
+                            {isOwner ? (
+                              <Button
+                                variant="destructive"
+                                size="sm"
+                                onClick={() => setWorkspaceToDelete(workspace)}
+                              >
+                                <Trash2Icon data-icon="inline-start" />
+                                Delete
+                              </Button>
+                            ) : null}
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })}
+                </TableBody>
+              </Table>
+            </div>}
           </CardContent>
         </Card>
-      ) : null}
-      <Card>
-        <CardHeader>
-          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-            <div>
-              <CardTitle>Your workspaces</CardTitle>
-              <CardDescription>
-                Manage the workspaces you own or have access to.
-              </CardDescription>
-            </div>
-            <Badge variant={canShareWorkspace ? "secondary" : "outline"}>
-              Current plan: {planLabel(entitlement.plan)}
-            </Badge>
-          </div>
-        </CardHeader>
-        <CardContent>
-          {workspaces.length === 0 ? (
-            <Empty>
-              <EmptyHeader>
-                <EmptyTitle>No workspaces yet</EmptyTitle>
-                <EmptyDescription>Create a workspace using the form above to start running scans.</EmptyDescription>
-              </EmptyHeader>
-            </Empty>
-          ) : <div className="overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Name</TableHead>
-                  <TableHead>Slug</TableHead>
-                  <TableHead>Type</TableHead>
-                  <TableHead className="text-right">Actions</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {workspaces.map((workspace) => {
-                  const isOwner = workspace.createdBy === currentUser.id
-
-                  return (
-                    <TableRow key={workspace.id}>
-                      <TableCell className="font-medium">{workspace.name}</TableCell>
-                      <TableCell>{workspace.slug}</TableCell>
-                      <TableCell>
-                        <Badge variant="outline">{isOwner ? "Owner" : "Shared"}</Badge>
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex justify-end gap-2">
-                          {isOwner ? (
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() => setShareUpgradeOpen(true)}
-                            >
-                              <Share2Icon data-icon="inline-start" />
-                              Share
-                            </Button>
-                          ) : null}
-                          {isOwner ? (
-                            <Button
-                              variant="destructive"
-                              size="sm"
-                              onClick={() => setWorkspaceToDelete(workspace)}
-                            >
-                              <Trash2Icon data-icon="inline-start" />
-                              Delete
-                            </Button>
-                          ) : null}
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  )
-                })}
-              </TableBody>
-            </Table>
-          </div>}
-        </CardContent>
-      </Card>
+        <DialogContent className="sm:max-w-md" showCloseButton={!pending}>
+          <DialogHeader>
+            <DialogTitle>New workspace</DialogTitle>
+            <DialogDescription>
+              {entitlement.plan === "free"
+                ? "Your Free plan includes one workspace. Use the default name or choose your own."
+                : "Give your workspace a name to keep your scans organized."}
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={createWorkspace} className="grid gap-5">
+            <Field data-invalid={Boolean(error)}>
+              <FieldLabel htmlFor="cloud-workspace-name">Workspace name</FieldLabel>
+              <Input
+                id="cloud-workspace-name"
+                value={name}
+                placeholder="personal"
+                onChange={(event) => setName(event.target.value)}
+                disabled={pending}
+                aria-invalid={Boolean(error)}
+                aria-describedby={error ? "cloud-workspace-error" : undefined}
+              />
+              {error ? <FieldError id="cloud-workspace-error" role="alert">{error}</FieldError> : null}
+            </Field>
+            <DialogFooter>
+              <Button type="button" variant="outline" disabled={pending} onClick={() => setCreateOpen(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={pending || !canCreateWorkspace}>
+                {pending ? "Creating workspace…" : "Create workspace"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
       <WorkspaceShareUpgradeDialog
         canShareWorkspace={canShareWorkspace}
         open={shareUpgradeOpen}
@@ -1301,15 +1319,25 @@ function BillingPanel() {
     async function confirmSubscription() {
       try {
         for (let attempt = 0; attempt < 10 && !cancelled; attempt++) {
-          const checkout = await apiRequest<{ status: string }>(
+          const checkout = await apiRequest<{
+            status: string
+            plan: Entitlement["plan"]
+            accountMatches: boolean
+          }>(
             `/api/v1/billing/checkout-session/${encodeURIComponent(sessionId!)}`
           )
           if (cancelled) return
           if (checkout.status === "active" || checkout.status === "trialing") {
+            if (checkout.accountMatches !== true) {
+              throw new Error("This checkout belongs to a different account. Sign in with the account used for the purchase, then reopen this return URL.")
+            }
             const billing = await loadStatus()
             if (cancelled) return
-            if (billing.entitlement.plan === "free") {
-              throw new Error("The subscription was confirmed, but is not linked to this account. Please contact support.")
+            if (
+              billing.entitlement.plan !== checkout.plan ||
+              !["active", "trialing"].includes(billing.entitlement.status)
+            ) {
+              throw new Error(`Your account has not activated the ${planLabel(checkout.plan)} plan yet. Refresh this page to check again, or contact support if it persists.`)
             }
             await refreshEntitlement()
             if (cancelled) return

--- a/frontend/src/components/runtz/app-shell.tsx
+++ b/frontend/src/components/runtz/app-shell.tsx
@@ -157,6 +157,14 @@ export function AppShell({
     React.useState(ALL_WORKSPACES)
   const [loading, setLoading] = React.useState(true)
 
+  const refreshEntitlement = React.useCallback(async () => {
+    if (isPlayground) return
+    const response = await apiRequest<{ entitlement: Entitlement }>(
+      "/api/v1/billing/status"
+    )
+    setEntitlement(response.entitlement)
+  }, [isPlayground])
+
   const refreshWorkspaces = React.useCallback(async () => {
     if (isPlayground) {
       setWorkspaces(PLAYGROUND_WORKSPACES)
@@ -263,6 +271,7 @@ export function AppShell({
           selectedWorkspaceId,
           setSelectedWorkspaceId,
           refreshWorkspaces,
+          refreshEntitlement,
         }}
       >
         <SidebarProvider className="runtz-app-surface">

--- a/frontend/src/components/runtz/workspace-context.tsx
+++ b/frontend/src/components/runtz/workspace-context.tsx
@@ -14,6 +14,7 @@ type WorkspaceContextValue = {
   selectedWorkspaceId: string
   setSelectedWorkspaceId: (workspaceId: string) => void
   refreshWorkspaces: () => Promise<void>
+  refreshEntitlement: () => Promise<void>
 }
 
 const WorkspaceContext = React.createContext<WorkspaceContextValue | null>(null)

--- a/helm/environments/README.md
+++ b/helm/environments/README.md
@@ -190,7 +190,9 @@ and verify the matching webhook returns HTTP 200 and the account status updates.
 The checkout return status check can recover the initial purchase without a webhook;
 renewals and cancellations still require the webhook to stay synchronized.
 The return page waits for an active or trialing subscription, verifies the account's
-entitlement, and refreshes the plan displayed throughout the app. Pending payments
+identity and that its entitlement matches the purchased plan, and refreshes the plan
+displayed throughout the app. A mismatched account or plan keeps the checkout URL
+available for retry instead of announcing activation. Pending payments
 remain pending; synchronization failures are reported and can be retried by
 refreshing the return page. Checkout and subscription webhooks reconcile the same
 billing record, including when deliveries arrive concurrently or in either order.

--- a/helm/environments/README.md
+++ b/helm/environments/README.md
@@ -189,6 +189,11 @@ Usage, then exercise the premium features. Also test cancellation in the portal
 and verify the matching webhook returns HTTP 200 and the account status updates.
 The checkout return status check can recover the initial purchase without a webhook;
 renewals and cancellations still require the webhook to stay synchronized.
+The return page waits for an active or trialing subscription, verifies the account's
+entitlement, and refreshes the plan displayed throughout the app. Pending payments
+remain pending; synchronization failures are reported and can be retried by
+refreshing the return page. Checkout and subscription webhooks reconcile the same
+billing record, including when deliveries arrive concurrently or in either order.
 
 References: [Stripe test cards](https://docs.stripe.com/testing) and
 [subscription webhooks](https://docs.stripe.com/billing/subscriptions/webhooks).


### PR DESCRIPTION
## What does this PR do?

Successful Stripe checkouts could remain `checkout_pending`: confirmation attempted to insert a subscription row with an already-used checkout ID, and the return endpoint swallowed the database error. The UI then announced activation on any HTTP 200 response.

Promote pending checkouts in place, reconcile rows created by subscription webhooks, and make retries and concurrent deliveries safe. Propagate synchronization errors, avoid storing empty subscription IDs, preserve subscription user metadata, and fetch current Stripe subscription state before applying delayed webhooks. The return page waits for an active subscription, verifies ownership against the signed-in account, requires the active entitlement to match the purchased plan, and refreshes the shared plan display. Account IDs take precedence over billing emails. A different paid account or a mismatched plan produces an error and preserves the checkout return URL for retry.

Regression coverage uses a disposable MongoDB with the real unique indexes: both delivery orders, concurrent/repeated events, early completion, stale events, pending checkouts, cancellation, identity fallback, Stripe errors and database write failures.

Workspace creation now opens from a compact outline button in the **Your workspaces** header, replacing the always-visible creation card. The dialog retains validation, plan limits, keyboard navigation and responsive layout.

## Base branch

- [x] This PR targets `dev`

## Checklist

- [x] `cd engine && go test ./...` passes with `RUNTZ_TEST_MONGO_URI` pointing at disposable local MongoDB
- [x] `go vet ./...` passes; billing concurrency regression tests also passed with `-race`
- [x] `cd frontend && npm run lint && npm run build` passes
- [x] No secrets, tokens or personal endpoints in the diff
- [x] Docs updated

## Generated by

- **Author:** Codex (GPT-6)
- **Task / prompt:** Fix paid checkout activation, address the review about purchased-plan/account matching, and move workspace creation into a compact action in the workspace list.
- **How it was verified:** Full Go tests and vet, real MongoDB integration tests, race detector, frontend lint and production build. Images built from commit 13f729f were deployed to dev as dev13f729f-billing. Both existing paid sandbox checkouts were recovered through the corrected public API and returned Pro/active; repeated confirmations returned the same billing record. Read-only Mongo verification found both active subscriptions linked to the account and zero duplicate subscription IDs. Backend health and frontend login returned HTTP 200. The initial fix at 13f729f is deployed to dev. The follow-up ownership/plan verification and workspace dialog are tested locally and pushed for review; they await merge/deployment. Browser checks against the production frontend build with mocked API responses covered different Pro/Enterprise accounts, mismatched plans, inactive entitlements, valid activation and preservation/removal of the return URL. Workspace checks passed at 1440px and 390px, including keyboard focus restoration, submit errors, successful creation, empty state and the Free plan limit. All Go tests and vet, frontend lint and build passed again for the follow-up.
- [ ] A human reviewed the full diff and takes responsibility for it
