### PR TITLE
Refine workspace selection and member management

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,10 +189,14 @@ self-updater and pipeline examples.
   results.
 - Workspaces, users, profiles, usage tracking and paid-plan billing.
 - The app header shows the current account plan next to the deployment mode.
-- Cloud workspace owners on Pro or Enterprise can open **Settings → Workspaces
-  → Share** to grant access by email to an existing Runtz account, list members,
-  and remove access. Members can view scans and manage workspace API keys; only
-  the owner manages sharing. New teammates must sign up before being added.
+- In **Settings → Workspaces**, select a workspace to open its overview and member
+  list below. The first workspace opens by default; newly created workspaces are
+  selected automatically. Owner and Shared tags identify your relationship to each
+  workspace. Members can view their team's roster, scans and workspace API keys;
+  only the owner manages sharing or deletes the workspace.
+- Cloud owners on Pro or Enterprise can use **Add member** in the details panel
+  to grant access to an existing Runtz account through a compact email-only form.
+  Members are managed directly in the panel. New teammates must sign up first.
   Pro allows 50 distinct users across the owner's workspaces (including the
   owner); sharing another workspace with an existing teammate uses the same seat.
   Removing a member revokes their workspace API keys. Owners can still remove

--- a/engine/internal/api/workspace_sharing.go
+++ b/engine/internal/api/workspace_sharing.go
@@ -45,8 +45,29 @@ func (s *Server) sharingWorkspace(w http.ResponseWriter, r *http.Request) (Works
 }
 
 func (s *Server) handleListWorkspaceMembers(w http.ResponseWriter, r *http.Request) {
-	workspace, _, ok := s.sharingWorkspace(w, r)
-	if !ok {
+	user, _ := currentUser(r.Context())
+	if s.cfg.DeploymentMode != hostingCloud {
+		writeError(w, http.StatusNotFound, "workspace sharing is only available in cloud mode")
+		return
+	}
+	id, err := bson.ObjectIDFromHex(r.PathValue("id"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid workspace id")
+		return
+	}
+	// Members may view their team's roster. Adding and removing members still
+	// use sharingWorkspace, which requires ownership regardless of global role.
+	var workspace Workspace
+	err = s.workspaces.FindOne(r.Context(), bson.M{
+		"_id": id,
+		"$or": []bson.M{{"created_by": user.ID}, {"_id": bson.M{"$in": user.WorkspaceIDs}}},
+	}).Decode(&workspace)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		writeError(w, http.StatusNotFound, "workspace not found or you do not have access")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load workspace")
 		return
 	}
 	cursor, err := s.users.Find(r.Context(), bson.M{"workspace_ids": workspace.ID}, options.Find().SetSort(bson.D{{Key: "email", Value: 1}}))

--- a/engine/internal/api/workspace_sharing_integration_test.go
+++ b/engine/internal/api/workspace_sharing_integration_test.go
@@ -70,6 +70,7 @@ func TestCloudWorkspaceSharing(t *testing.T) {
 	}
 	request(ownerToken, http.MethodPost, endpoint, `{"email":"invalid"}`, http.StatusBadRequest)
 	request(ownerToken, http.MethodPost, endpoint, `{"email":"unknown@gmail.com"}`, http.StatusNotFound)
+	request(memberToken, http.MethodGet, endpoint, "", http.StatusNotFound)
 	request(memberToken, http.MethodGet, "/api/v1/api-keys?workspaceId="+workspace.ID.Hex(), "", http.StatusForbidden)
 	request(ownerToken, http.MethodPost, endpoint, memberBody, http.StatusOK)
 	request(ownerToken, http.MethodPost, endpoint, memberBody, http.StatusOK)
@@ -96,6 +97,10 @@ func TestCloudWorkspaceSharing(t *testing.T) {
 		t.Fatal("member must see both shared and personal workspaces")
 	}
 	request(memberToken, http.MethodGet, "/api/v1/api-keys?workspaceId="+workspace.ID.Hex(), "", http.StatusOK)
+	memberList := request(memberToken, http.MethodGet, endpoint, "", http.StatusOK)
+	if memberList.Body.String() != list.Body.String() {
+		t.Fatal("members must see the same roster as the owner")
+	}
 	request(memberToken, http.MethodPost, endpoint, memberBody, http.StatusNotFound)
 	request(memberToken, http.MethodDelete, endpoint+"/"+owner.ID.Hex(), "", http.StatusNotFound)
 	request(ownerToken, http.MethodDelete, endpoint+"/"+owner.ID.Hex(), "", http.StatusBadRequest)
@@ -119,6 +124,7 @@ func TestCloudWorkspaceSharing(t *testing.T) {
 	}
 	request(ownerToken, http.MethodGet, endpoint, "", http.StatusOK)
 	request(ownerToken, http.MethodDelete, endpoint+"/"+member.ID.Hex(), "", http.StatusOK)
+	request(memberToken, http.MethodGet, endpoint, "", http.StatusNotFound)
 	request(memberToken, http.MethodGet, "/api/v1/api-keys?workspaceId="+workspace.ID.Hex(), "", http.StatusForbidden)
 	if _, _, err := s.workspaceFromAPIKey(ctx, key.Token); err == nil {
 		t.Fatal("removed member key still works")

--- a/frontend/src/app/app/settings/page.tsx
+++ b/frontend/src/app/app/settings/page.tsx
@@ -5,6 +5,9 @@ import {
   ActivityIcon,
   ArrowUpRightIcon,
   CopyIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
+  FolderIcon,
   CreditCardIcon,
   CrownIcon,
   KeyRoundIcon,
@@ -17,7 +20,7 @@ import {
 } from "lucide-react"
 
 import { useWorkspace } from "@/components/runtz/workspace-context"
-import { WorkspaceSharingDialog } from "@/components/runtz/workspace-sharing-dialog"
+import { WorkspaceDetailsPanel } from "@/components/runtz/workspace-details-panel"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -362,7 +365,9 @@ function SelfHostedWorkspacesLimitPanel() {
 }
 
 function CloudWorkspacesPanel() {
-  const { currentUser, entitlement, workspaces, refreshWorkspaces } = useWorkspace()
+  const { currentUser, entitlement, workspaces, selectedWorkspaceId, refreshWorkspaces } = useWorkspace()
+  const [activeWorkspaceId, setActiveWorkspaceId] = React.useState(selectedWorkspaceId)
+  const activeWorkspace = workspaces.find((workspace) => workspace.id === activeWorkspaceId) ?? workspaces[0]
   const [name, setName] = React.useState("personal")
   const [pending, setPending] = React.useState(false)
   const [error, setError] = React.useState("")
@@ -376,11 +381,12 @@ function CloudWorkspacesPanel() {
     setPending(true)
     setError("")
     try {
-      await apiRequest("/api/v1/workspaces", {
+      const response = await apiRequest<{ workspace: Workspace }>("/api/v1/workspaces", {
         method: "POST",
         body: { name: name.trim() || "personal" },
       })
       await refreshWorkspaces()
+      setActiveWorkspaceId(response.workspace.id)
       setName("personal")
       setCreateOpen(false)
     } catch (error) {
@@ -391,7 +397,6 @@ function CloudWorkspacesPanel() {
   }
 
   const [workspaceToDelete, setWorkspaceToDelete] = React.useState<Workspace | null>(null)
-  const canShareWorkspace = entitlement.plan === "pro" || entitlement.plan === "enterprise"
 
   return (
     <div className="flex flex-col gap-6">
@@ -407,15 +412,12 @@ function CloudWorkspacesPanel() {
           <CardHeader>
             <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
               <div>
-                <CardTitle>Your workspaces</CardTitle>
+                <CardTitle>Your workspaces <span className="ml-1 text-muted-foreground">({workspaces.length})</span></CardTitle>
                 <CardDescription>
-                  Manage the workspaces you own or have access to.
+                  Select a workspace to view its details and members.
                 </CardDescription>
               </div>
               <div className="flex flex-wrap items-center gap-3 sm:shrink-0">
-                <Badge variant={canShareWorkspace ? "secondary" : "outline"}>
-                  Current plan: {planLabel(entitlement.plan)}
-                </Badge>
                 {canCreateWorkspace ? (
                   <DialogTrigger render={<Button variant="outline" size="sm" className="h-10 sm:h-8" />}>
                     <PlusIcon data-icon="inline-start" />
@@ -433,50 +435,42 @@ function CloudWorkspacesPanel() {
                   <EmptyDescription>Select New workspace to organize your scans and get started.</EmptyDescription>
                 </EmptyHeader>
               </Empty>
-            ) : <div className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Name</TableHead>
-                    <TableHead>Slug</TableHead>
-                    <TableHead>Type</TableHead>
-                    <TableHead className="text-right">Actions</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
+            ) : (
+              <div className="flex flex-col gap-2">
+                <div aria-hidden="true" className="grid grid-cols-[minmax(0,1fr)_76px_20px] gap-3 px-3 text-xs text-muted-foreground lg:grid-cols-[minmax(0,1fr)_100px_140px_20px]">
+                  <span>Workspace</span>
+                  <span>Type</span>
+                  <span className="hidden lg:block">Created</span>
+                  <span />
+                </div>
+                <ul aria-label="Workspaces" className="flex max-h-72 flex-col gap-1 overflow-y-auto p-1">
                   {workspaces.map((workspace) => {
+                    const isActive = workspace.id === activeWorkspace?.id
                     const isOwner = workspace.createdBy === currentUser.id
-
                     return (
-                      <TableRow key={workspace.id}>
-                        <TableCell className="font-medium">{workspace.name}</TableCell>
-                        <TableCell>{workspace.slug}</TableCell>
-                        <TableCell>
-                          <Badge variant="outline">{isOwner ? "Owner" : "Shared"}</Badge>
-                        </TableCell>
-                        <TableCell>
-                          <div className="flex justify-end gap-2">
-                            {isOwner ? (
-                              <WorkspaceSharingDialog workspace={workspace} onUpgrade={openBillingTab} />
-                            ) : null}
-                            {isOwner ? (
-                              <Button
-                                variant="destructive"
-                                size="sm"
-                                onClick={() => setWorkspaceToDelete(workspace)}
-                              >
-                                <Trash2Icon data-icon="inline-start" />
-                                Delete
-                              </Button>
-                            ) : null}
-                          </div>
-                        </TableCell>
-                      </TableRow>
+                      <li key={workspace.id}>
+                        <Button
+                          variant={isActive ? "secondary" : "ghost"}
+                          className="grid h-auto w-full grid-cols-[minmax(0,1fr)_76px_20px] items-center justify-stretch gap-3 px-3 py-3 text-left lg:grid-cols-[minmax(0,1fr)_100px_140px_20px]"
+                          aria-label={`View ${workspace.name} workspace`}
+                          aria-pressed={isActive}
+                          aria-controls="workspace-details"
+                          onClick={() => setActiveWorkspaceId(workspace.id)}
+                        >
+                          <span className="flex min-w-0 items-center gap-3">
+                            <FolderIcon aria-hidden="true" />
+                            <span className="truncate" title={workspace.name}>{workspace.name}</span>
+                          </span>
+                          <Badge variant="outline" className="justify-self-start">{isOwner ? "Owner" : "Shared"}</Badge>
+                          <span className="hidden text-xs font-normal text-muted-foreground lg:block">{new Intl.DateTimeFormat("en-US", { dateStyle: "medium" }).format(new Date(workspace.createdAt))}</span>
+                          {isActive ? <ChevronDownIcon aria-hidden="true" /> : <ChevronRightIcon aria-hidden="true" />}
+                        </Button>
+                      </li>
                     )
                   })}
-                </TableBody>
-              </Table>
-            </div>}
+                </ul>
+              </div>
+            )}
           </CardContent>
         </Card>
         <DialogContent className="sm:max-w-md" showCloseButton={!pending}>
@@ -513,6 +507,14 @@ function CloudWorkspacesPanel() {
           </form>
         </DialogContent>
       </Dialog>
+      {activeWorkspace ? (
+        <WorkspaceDetailsPanel
+          key={activeWorkspace.id}
+          workspace={activeWorkspace}
+          onUpgrade={openBillingTab}
+          onDelete={() => setWorkspaceToDelete(activeWorkspace)}
+        />
+      ) : null}
       <WorkspaceDeletionDialog
         workspace={workspaceToDelete}
         open={Boolean(workspaceToDelete)}

--- a/frontend/src/components/runtz/app-shell.tsx
+++ b/frontend/src/components/runtz/app-shell.tsx
@@ -377,12 +377,12 @@ export function AppShell({
               </SidebarMenu>
             </SidebarFooter>
           </Sidebar>
-          <SidebarInset>
+          <SidebarInset className="min-w-0">
           <header className="flex h-14 shrink-0 items-center gap-3 border-b border-border bg-background px-4 text-[#071222] backdrop-blur dark:border-[#213047] dark:bg-[#050912]/88 dark:text-[#eaf4ff]">
             <SidebarTrigger />
             <Separator orientation="vertical" className="h-5" />
             <div className="flex min-w-0 flex-1 items-center gap-3">
-              <span className="hidden shrink-0 text-sm font-medium text-muted-foreground sm:inline">
+              <span className="hidden shrink-0 text-sm font-medium text-muted-foreground lg:inline">
                 Workspace
               </span>
               <Select
@@ -398,7 +398,7 @@ export function AppShell({
                   ...workspaces.map((workspace) => ({ value: workspace.id, label: workspace.name })),
                 ]}
               >
-                <SelectTrigger className="w-full min-w-0 sm:w-56" aria-label="Workspace">
+                <SelectTrigger className="w-full min-w-0 sm:w-56 sm:max-w-full" aria-label="Workspace">
                   <SelectValue placeholder={workspaces.length === 0 ? "No workspaces" : "Select"} />
                 </SelectTrigger>
                 <SelectContent>

--- a/frontend/src/components/runtz/workspace-details-panel.tsx
+++ b/frontend/src/components/runtz/workspace-details-panel.tsx
@@ -1,0 +1,185 @@
+"use client"
+
+import * as React from "react"
+import { LockKeyholeIcon, RefreshCcwIcon, Trash2Icon, UsersIcon } from "lucide-react"
+
+import { useWorkspace } from "@/components/runtz/workspace-context"
+import { WorkspaceSharingDialog } from "@/components/runtz/workspace-sharing-dialog"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@/components/ui/empty"
+import { FieldError } from "@/components/ui/field"
+import { Separator } from "@/components/ui/separator"
+import { Skeleton } from "@/components/ui/skeleton"
+import { apiRequest, type Workspace } from "@/lib/api"
+
+type WorkspaceMember = {
+  id: string
+  email: string
+  name: string
+  role: "owner" | "member"
+}
+
+export function WorkspaceDetailsPanel({
+  workspace,
+  onDelete,
+  onUpgrade,
+}: {
+  workspace: Workspace
+  onDelete: () => void
+  onUpgrade: () => void
+}) {
+  const { currentUser, entitlement } = useWorkspace()
+  const isOwner = workspace.createdBy === currentUser.id
+  const canShare = entitlement.plan === "pro" || entitlement.plan === "enterprise"
+  const [members, setMembers] = React.useState<WorkspaceMember[]>([])
+  const [loading, setLoading] = React.useState(true)
+  const [loadError, setLoadError] = React.useState("")
+  const [error, setError] = React.useState("")
+  const [message, setMessage] = React.useState("")
+  const [removingId, setRemovingId] = React.useState<string | null>(null)
+  const endpoint = `/api/v1/workspaces/${workspace.id}/members`
+
+  const loadMembers = React.useCallback(async (signal?: AbortSignal) => {
+    setLoading(true)
+    setLoadError("")
+    try {
+      const response = await apiRequest<{ members: WorkspaceMember[] }>(endpoint, { signal })
+      if (!signal?.aborted) setMembers(response.members)
+    } catch (error) {
+      if (!signal?.aborted) setLoadError(error instanceof Error ? error.message : "Failed to load members")
+    } finally {
+      if (!signal?.aborted) setLoading(false)
+    }
+  }, [endpoint])
+
+  React.useEffect(() => {
+    const controller = new AbortController()
+    void loadMembers(controller.signal)
+    return () => controller.abort()
+  }, [loadMembers])
+
+  async function removeMember(member: WorkspaceMember) {
+    if (removingId) return
+    setRemovingId(member.id)
+    setError("")
+    setMessage("")
+    try {
+      await apiRequest(`${endpoint}/${member.id}`, { method: "DELETE" })
+      setMembers((current) => current.filter((item) => item.id !== member.id))
+      setMessage(`Access removed for ${member.email || member.name}.`)
+    } catch (error) {
+      setError(error instanceof Error ? error.message : "Failed to remove member")
+    } finally {
+      setRemovingId(null)
+    }
+  }
+
+  const sortedMembers = [...members].sort((a, b) =>
+    Number(b.role === "owner") - Number(a.role === "owner") || (a.name || a.email).localeCompare(b.name || b.email)
+  )
+
+  return (
+    <section id="workspace-details" aria-labelledby={`workspace-title-${workspace.id}`}>
+      <Card>
+        <CardHeader className="gap-4 sm:flex sm:items-center sm:justify-between">
+          <div className="flex min-w-0 flex-col gap-1.5">
+            <p className="text-xs font-medium text-muted-foreground">Workspace details</p>
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              <CardTitle><h2 id={`workspace-title-${workspace.id}`} className="break-all">{workspace.name}</h2></CardTitle>
+              <Badge variant="outline">{isOwner ? "Owner" : "Shared"}</Badge>
+            </div>
+            <CardDescription>{isOwner ? "Manage your workspace and the people with access." : "A shared workspace you belong to."}</CardDescription>
+          </div>
+          {isOwner ? (
+            <div className="shrink-0 self-start sm:self-center">
+              {canShare ? (
+                <WorkspaceSharingDialog workspace={workspace} disabled={Boolean(removingId)} onAdded={(email) => {
+                  setError("")
+                  setMessage(`Access granted to ${email}.`)
+                  void loadMembers()
+                }} />
+              ) : (
+                <Button variant="outline" onClick={onUpgrade}>
+                  <LockKeyholeIcon data-icon="inline-start" />
+                  Upgrade to add members
+                </Button>
+              )}
+            </div>
+          ) : null}
+        </CardHeader>
+        <Separator />
+        <CardContent className="grid gap-6 lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-8">
+          <section aria-label="Workspace information" className="flex min-w-0 flex-col gap-4 lg:border-r lg:pr-8">
+            <h3 className="text-sm font-medium">Overview</h3>
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-5 lg:grid-cols-1">
+              <div className="min-w-0">
+                <dt className="text-xs text-muted-foreground">Slug</dt>
+                <dd className="mt-1.5 break-all text-sm">{workspace.slug}</dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted-foreground">Created</dt>
+                <dd className="mt-1.5 text-sm">{new Intl.DateTimeFormat("en-US", { dateStyle: "medium" }).format(new Date(workspace.createdAt))}</dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted-foreground">Your access</dt>
+                <dd className="mt-1.5 text-sm">{isOwner ? "Workspace owner" : "Workspace member"}</dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted-foreground">Members</dt>
+                <dd className="mt-1.5 text-sm">{loading ? <Skeleton className="h-5 w-8" /> : loadError ? "Unavailable" : members.length}</dd>
+              </div>
+            </dl>
+          </section>
+          <section aria-label="Workspace members" className="flex min-w-0 flex-col gap-4">
+            <div>
+              <h3 className="flex items-center gap-2 text-sm font-medium"><UsersIcon className="size-4 text-muted-foreground" />Members</h3>
+              <p className="mt-1 text-sm text-muted-foreground">Members can view scans and manage workspace API keys.</p>
+            </div>
+            {message ? <p role="status" className="break-words text-sm text-muted-foreground">{message}</p> : null}
+            {error ? <FieldError role="alert">{error}</FieldError> : null}
+            {loading ? (
+              <div aria-label="Loading members" className="flex flex-col gap-4">
+                {[0, 1].map((item) => <div key={item} className="flex items-center gap-3"><Skeleton className="size-8 rounded-full" /><Skeleton className="h-9 w-48 max-w-full" /></div>)}
+              </div>
+            ) : loadError ? (
+              <div className="flex flex-col items-start gap-3">
+                <FieldError role="alert">{loadError}</FieldError>
+                <Button variant="outline" size="sm" onClick={() => void loadMembers()}><RefreshCcwIcon data-icon="inline-start" />Retry</Button>
+              </div>
+            ) : sortedMembers.length === 0 ? (
+              <Empty><EmptyHeader><EmptyTitle>No members to display</EmptyTitle><EmptyDescription>Workspace access will appear here.</EmptyDescription></EmptyHeader></Empty>
+            ) : (
+              <ul className="flex flex-col divide-y divide-border">
+                {sortedMembers.map((member) => (
+                  <li key={member.id} className="flex items-center gap-3 py-3 first:pt-0 last:pb-0">
+                    <Avatar><AvatarFallback>{(member.name || member.email).slice(0, 2).toUpperCase()}</AvatarFallback></Avatar>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium" title={member.name || member.email}>{member.name || member.email}{member.id === currentUser.id ? <span className="ml-1 font-normal text-muted-foreground">(you)</span> : null}</p>
+                      <p className="truncate text-xs text-muted-foreground" title={member.email}>{member.email}</p>
+                    </div>
+                    <Badge variant={member.role === "owner" ? "secondary" : "outline"}>{member.role === "owner" ? "Owner" : "Member"}</Badge>
+                    {isOwner && member.role !== "owner" ? (
+                      <Button variant="ghost" size="sm" disabled={Boolean(removingId)} onClick={() => void removeMember(member)} aria-label={`Remove access for ${member.email || member.name}`}>
+                        {removingId === member.id ? "Removing…" : "Remove"}
+                      </Button>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            )}
+            {!isOwner ? <p className="text-xs text-muted-foreground">Only the workspace owner can add or remove members.</p> : null}
+          </section>
+        </CardContent>
+        {isOwner ? (
+          <CardFooter className="flex-col items-start justify-between gap-3 sm:flex-row sm:items-center">
+            <p className="text-xs text-muted-foreground">Deleting this workspace permanently removes its scans and API keys.</p>
+            <Button variant="destructive" size="sm" disabled={Boolean(removingId)} onClick={onDelete}><Trash2Icon data-icon="inline-start" />Delete workspace</Button>
+          </CardFooter>
+        ) : null}
+      </Card>
+    </section>
+  )
+}

--- a/frontend/src/components/runtz/workspace-sharing-dialog.tsx
+++ b/frontend/src/components/runtz/workspace-sharing-dialog.tsx
@@ -1,94 +1,51 @@
 "use client"
 
 import * as React from "react"
-import { Share2Icon } from "lucide-react"
+import { UserPlusIcon } from "lucide-react"
 
-import { useWorkspace } from "@/components/runtz/workspace-context"
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
 import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
-import { Skeleton } from "@/components/ui/skeleton"
 import { apiRequest, type Workspace } from "@/lib/api"
 
-type WorkspaceMember = {
-  id: string
-  email: string
-  name: string
-  role: "owner" | "member"
-}
-
-export function WorkspaceSharingDialog({ workspace, onUpgrade }: { workspace: Workspace; onUpgrade: () => void }) {
-  const { entitlement } = useWorkspace()
-  const canShare = entitlement.plan === "pro" || entitlement.plan === "enterprise"
+export function WorkspaceSharingDialog({
+  workspace,
+  onAdded,
+  disabled = false,
+}: {
+  workspace: Workspace
+  onAdded: (email: string) => void
+  disabled?: boolean
+}) {
   const [open, setOpen] = React.useState(false)
-  const [members, setMembers] = React.useState<WorkspaceMember[]>([])
   const [email, setEmail] = React.useState("")
-  const [loading, setLoading] = React.useState(true)
-  const [loadError, setLoadError] = React.useState("")
   const [error, setError] = React.useState("")
-  const [message, setMessage] = React.useState("")
   const [pending, setPending] = React.useState(false)
-  const endpoint = `/api/v1/workspaces/${workspace.id}/members`
-
-  const loadMembers = React.useCallback(async (signal?: AbortSignal) => {
-    setLoading(true)
-    setLoadError("")
-    try {
-      const response = await apiRequest<{ members: WorkspaceMember[] }>(endpoint, { signal })
-      if (!signal?.aborted) setMembers(response.members)
-    } catch (error) {
-      if (!signal?.aborted) setLoadError(error instanceof Error ? error.message : "Failed to load members")
-    } finally {
-      if (!signal?.aborted) setLoading(false)
-    }
-  }, [endpoint])
-
-  React.useEffect(() => {
-    if (!open) return
-    const controller = new AbortController()
-    void loadMembers(controller.signal)
-    return () => controller.abort()
-  }, [open, loadMembers])
 
   function handleOpenChange(nextOpen: boolean) {
     if (pending) return
     setOpen(nextOpen)
     setEmail("")
     setError("")
-    setMessage("")
   }
 
   async function shareWorkspace(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
-    if (pending || !canShare) return
+    if (pending) return
     setPending(true)
     setError("")
-    setMessage("")
     try {
       const address = email.trim().toLowerCase()
-      await apiRequest(endpoint, { method: "POST", body: { email: address } })
+      await apiRequest(`/api/v1/workspaces/${workspace.id}/members`, {
+        method: "POST",
+        body: { email: address },
+      })
+      setOpen(false)
       setEmail("")
-      setMessage(`Access granted to ${address}.`)
-      await loadMembers()
+      onAdded(address)
     } catch (error) {
-      setError(error instanceof Error ? error.message : "Failed to share workspace")
-    } finally {
-      setPending(false)
-    }
-  }
-
-  async function removeMember(member: WorkspaceMember) {
-    setPending(true)
-    setError("")
-    setMessage("")
-    try {
-      await apiRequest(`${endpoint}/${member.id}`, { method: "DELETE" })
-      setMembers((current) => current.filter((item) => item.id !== member.id))
-      setMessage(`Access removed for ${member.email || member.name}.`)
-    } catch (error) {
-      setError(error instanceof Error ? error.message : "Failed to remove member")
+      setError(error instanceof Error ? error.message : "Failed to add member")
     } finally {
       setPending(false)
     }
@@ -96,81 +53,44 @@ export function WorkspaceSharingDialog({ workspace, onUpgrade }: { workspace: Wo
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogTrigger render={<Button variant="outline" size="sm" />}>
-        <Share2Icon data-icon="inline-start" />
-        Share
+      <DialogTrigger render={<Button disabled={disabled} />}>
+        <UserPlusIcon data-icon="inline-start" />
+        Add member
       </DialogTrigger>
-      <DialogContent className="max-h-[85svh] overflow-y-auto sm:max-w-lg" showCloseButton={!pending}>
+      <DialogContent className="sm:max-w-md" showCloseButton={!pending}>
         <DialogHeader>
-          <DialogTitle>Share workspace</DialogTitle>
+          <DialogTitle>Add member</DialogTitle>
           <DialogDescription className="break-words">
-            Manage access to <strong>{workspace.name}</strong>. Members can view scans and manage workspace API keys.
+            Give someone access to <strong>{workspace.name}</strong>.
           </DialogDescription>
         </DialogHeader>
-        {canShare ? (
-          <form onSubmit={shareWorkspace}>
-            <FieldGroup>
-              <Field data-invalid={Boolean(error)}>
-                <FieldLabel htmlFor={`share-email-${workspace.id}`}>Email address</FieldLabel>
-                <div className="flex flex-col gap-2 sm:flex-row">
-                  <Input
-                    id={`share-email-${workspace.id}`}
-                    type="email"
-                    autoComplete="email"
-                    placeholder="colleague@company.com"
-                    value={email}
-                    onChange={(event) => setEmail(event.target.value)}
-                    required
-                    disabled={pending}
-                    aria-invalid={Boolean(error)}
-                    aria-describedby={`share-help-${workspace.id}`}
-                  />
-                  <Button type="submit" disabled={pending || !email.trim()}>
-                    {pending ? "Saving…" : "Add member"}
-                  </Button>
-                </div>
-                <FieldDescription id={`share-help-${workspace.id}`}>
-                  Use the email of an existing Runtz account. Access is granted immediately.
-                </FieldDescription>
-              </Field>
-            </FieldGroup>
-          </form>
-        ) : (
-          <div className="flex flex-col items-start gap-3">
-            <p className="text-sm text-muted-foreground">Upgrade to Pro to add members. You can still remove existing access below.</p>
-            <Button onClick={() => { handleOpenChange(false); onUpgrade() }}>Upgrade to Pro</Button>
-          </div>
-        )}
-        {error ? <FieldError role="alert">{error}</FieldError> : null}
-        {message ? <p role="status" className="break-words text-sm text-muted-foreground">{message}</p> : null}
-        <section aria-label="People with access" className="flex flex-col gap-3">
-          <h3 className="text-sm font-medium">People with access</h3>
-          {loading ? <Skeleton className="h-16 w-full" /> : loadError ? (
-            <div className="flex flex-col items-start gap-2">
-              <FieldError role="alert">{loadError}</FieldError>
-              <Button variant="outline" size="sm" onClick={() => void loadMembers()}>Retry</Button>
-            </div>
-          ) : (
-            <ul className="flex max-h-64 flex-col gap-3 overflow-y-auto">
-              {members.map((member) => (
-                <li key={member.id} className="flex items-center justify-between gap-3">
-                  <div className="min-w-0">
-                    <p className="truncate text-sm font-medium">{member.name || member.email}</p>
-                    <p className="truncate text-xs text-muted-foreground" title={member.email}>{member.email}</p>
-                  </div>
-                  {member.role === "owner" ? <Badge variant="secondary">Owner</Badge> : (
-                    <Button variant="outline" size="sm" disabled={pending} onClick={() => void removeMember(member)} aria-label={`Remove access for ${member.email || member.name}`}>
-                      Remove
-                    </Button>
-                  )}
-                </li>
-              ))}
-            </ul>
-          )}
-        </section>
-        <DialogFooter>
-          <Button variant="outline" disabled={pending} onClick={() => handleOpenChange(false)}>Done</Button>
-        </DialogFooter>
+        <form onSubmit={shareWorkspace} className="flex flex-col gap-5">
+          <FieldGroup>
+            <Field data-invalid={Boolean(error)}>
+              <FieldLabel htmlFor={`share-email-${workspace.id}`}>Email address</FieldLabel>
+              <Input
+                id={`share-email-${workspace.id}`}
+                type="email"
+                autoComplete="email"
+                placeholder="colleague@company.com"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                required
+                disabled={pending}
+                aria-invalid={Boolean(error)}
+                aria-describedby={`share-help-${workspace.id}${error ? ` share-error-${workspace.id}` : ""}`}
+              />
+              <FieldDescription id={`share-help-${workspace.id}`}>
+                Use an existing Runtz account. Access is granted immediately.
+              </FieldDescription>
+              {error ? <FieldError id={`share-error-${workspace.id}`} role="alert">{error}</FieldError> : null}
+            </Field>
+          </FieldGroup>
+          <DialogFooter>
+            <Button type="button" variant="outline" disabled={pending} onClick={() => handleOpenChange(false)}>Cancel</Button>
+            <Button type="submit" disabled={pending || !email.trim()}>{pending ? "Adding…" : "Add member"}</Button>
+          </DialogFooter>
+        </form>
       </DialogContent>
     </Dialog>
   )


### PR DESCRIPTION
## What does this PR do?

Selecting a workspace now opens its overview and member list below the workspace list. The selected row is highlighted, Owner/Shared badges remain visible, and newly created workspaces are selected automatically. Adding a member uses a compact email-only dialog; member removal and workspace deletion live in the details panel.

Workspace members can read their team's roster while only owners may add or remove members or delete the workspace. The header and workspace list adapt to tablet widths without horizontal overflow. README documents the new flow.

## Base branch

- [x] This PR targets `dev`

## Checklist

- [x] `cd engine && go test ./...` passes, including integration tests with disposable MongoDB
- [x] `cd engine && go vet ./...` passes
- [x] `cd frontend && npm run lint && npm run build` passes
- [x] No Helm changes; chart lint not applicable
- [x] No secrets, tokens or personal endpoints in the diff
- [x] Docs updated

## Generated by

- **Author:** Codex (GPT-6)
- **Task / prompt:** Make workspaces selectable, show details and members beneath the list, simplify adding a member to an email-only modal, and publish to dev at the user's request.
- **How it was verified:** Full Go tests with disposable MongoDB and go vet; frontend lint and production build. Playwright verified selection, shared-member permissions, form submission, errors and retry, member removal, workspace creation/deletion, keyboard focus, billing navigation and overflow at 375px, 768px, 1280px and 1900px, plus the light theme at 1440px. Screenshots reviewed; tablet layout refined and rechecked.
- [ ] A human reviewed the full diff and takes responsibility for it

By submitting this pull request, I agree that my contribution is provided under the project license (BUSL-1.1) as described in CONTRIBUTING.md.
