### PR TITLE
Simplify workspace members and restore row actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,14 +189,15 @@ self-updater and pipeline examples.
   results.
 - Workspaces, users, profiles, usage tracking and paid-plan billing.
 - The app header shows the current account plan next to the deployment mode.
-- In **Settings → Workspaces**, select a workspace to open its overview and member
-  list below. The first workspace opens by default; newly created workspaces are
+- In **Settings → Workspaces**, select a workspace to show its member list below.
+  The selected row is highlighted. The first workspace opens by default; newly created workspaces are
   selected automatically. Owner and Shared tags identify your relationship to each
   workspace. Members can view their team's roster, scans and workspace API keys;
   only the owner manages sharing or deletes the workspace.
-- Cloud owners on Pro or Enterprise can use **Add member** in the details panel
+- Cloud owners on Pro or Enterprise can use **Share** in the workspace row
   to grant access to an existing Runtz account through a compact email-only form.
-  Members are managed directly in the panel. New teammates must sign up first.
+  Members are managed directly in the list below; **Delete** stays in the workspace
+  row. New teammates must sign up first.
   Pro allows 50 distinct users across the owner's workspaces (including the
   owner); sharing another workspace with an existing teammate uses the same seat.
   Removing a member revokes their workspace API keys. Owners can still remove

--- a/frontend/src/app/app/settings/page.tsx
+++ b/frontend/src/app/app/settings/page.tsx
@@ -5,9 +5,6 @@ import {
   ActivityIcon,
   ArrowUpRightIcon,
   CopyIcon,
-  ChevronDownIcon,
-  ChevronRightIcon,
-  FolderIcon,
   CreditCardIcon,
   CrownIcon,
   KeyRoundIcon,
@@ -21,6 +18,7 @@ import {
 
 import { useWorkspace } from "@/components/runtz/workspace-context"
 import { WorkspaceDetailsPanel } from "@/components/runtz/workspace-details-panel"
+import { WorkspaceSharingDialog } from "@/components/runtz/workspace-sharing-dialog"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -367,6 +365,8 @@ function SelfHostedWorkspacesLimitPanel() {
 function CloudWorkspacesPanel() {
   const { currentUser, entitlement, workspaces, selectedWorkspaceId, refreshWorkspaces } = useWorkspace()
   const [activeWorkspaceId, setActiveWorkspaceId] = React.useState(selectedWorkspaceId)
+  const [membersVersion, setMembersVersion] = React.useState(0)
+  const canShareWorkspace = entitlement.plan === "pro" || entitlement.plan === "enterprise"
   const activeWorkspace = workspaces.find((workspace) => workspace.id === activeWorkspaceId) ?? workspaces[0]
   const [name, setName] = React.useState("personal")
   const [pending, setPending] = React.useState(false)
@@ -414,7 +414,7 @@ function CloudWorkspacesPanel() {
               <div>
                 <CardTitle>Your workspaces <span className="ml-1 text-muted-foreground">({workspaces.length})</span></CardTitle>
                 <CardDescription>
-                  Select a workspace to view its details and members.
+                  Select a workspace to view its members.
                 </CardDescription>
               </div>
               <div className="flex flex-wrap items-center gap-3 sm:shrink-0">
@@ -437,34 +437,55 @@ function CloudWorkspacesPanel() {
               </Empty>
             ) : (
               <div className="flex flex-col gap-2">
-                <div aria-hidden="true" className="grid grid-cols-[minmax(0,1fr)_76px_20px] gap-3 px-3 text-xs text-muted-foreground lg:grid-cols-[minmax(0,1fr)_100px_140px_20px]">
+                <div aria-hidden="true" className="grid grid-cols-[minmax(0,1fr)_120px] gap-3 px-3 text-xs text-muted-foreground lg:grid-cols-[minmax(0,1fr)_80px_120px_120px]">
                   <span>Workspace</span>
-                  <span>Type</span>
+                  <span className="hidden lg:block">Type</span>
                   <span className="hidden lg:block">Created</span>
-                  <span />
+                  <span className="text-right">Actions</span>
                 </div>
                 <ul aria-label="Workspaces" className="flex max-h-72 flex-col gap-1 overflow-y-auto p-1">
                   {workspaces.map((workspace) => {
                     const isActive = workspace.id === activeWorkspace?.id
                     const isOwner = workspace.createdBy === currentUser.id
                     return (
-                      <li key={workspace.id}>
+                      <li key={workspace.id} className="relative">
                         <Button
                           variant={isActive ? "secondary" : "ghost"}
-                          className="grid h-auto w-full grid-cols-[minmax(0,1fr)_76px_20px] items-center justify-stretch gap-3 px-3 py-3 text-left lg:grid-cols-[minmax(0,1fr)_100px_140px_20px]"
+                          className="absolute inset-0 size-full"
                           aria-label={`View ${workspace.name} workspace`}
                           aria-pressed={isActive}
                           aria-controls="workspace-details"
                           onClick={() => setActiveWorkspaceId(workspace.id)}
                         >
-                          <span className="flex min-w-0 items-center gap-3">
-                            <FolderIcon aria-hidden="true" />
-                            <span className="truncate" title={workspace.name}>{workspace.name}</span>
-                          </span>
-                          <Badge variant="outline" className="justify-self-start">{isOwner ? "Owner" : "Shared"}</Badge>
-                          <span className="hidden text-xs font-normal text-muted-foreground lg:block">{new Intl.DateTimeFormat("en-US", { dateStyle: "medium" }).format(new Date(workspace.createdAt))}</span>
-                          {isActive ? <ChevronDownIcon aria-hidden="true" /> : <ChevronRightIcon aria-hidden="true" />}
+                          <span className="sr-only">{workspace.name}</span>
                         </Button>
+                        <div className="pointer-events-none relative grid grid-cols-[minmax(0,1fr)_120px] items-center gap-3 px-3 py-3 lg:grid-cols-[minmax(0,1fr)_80px_120px_120px]">
+                          <div className="flex min-w-0 flex-col items-start gap-1.5">
+                            <span className="w-full truncate text-sm font-medium" title={workspace.name}>{workspace.name}</span>
+                            <Badge variant="outline" className="lg:hidden">{isOwner ? "Owner" : "Shared"}</Badge>
+                          </div>
+                          <Badge variant="outline" className="hidden justify-self-start lg:inline-flex">{isOwner ? "Owner" : "Shared"}</Badge>
+                          <span className="hidden text-xs text-muted-foreground lg:block">{new Intl.DateTimeFormat("en-US", { dateStyle: "medium" }).format(new Date(workspace.createdAt))}</span>
+                          <div className="pointer-events-auto flex justify-end gap-2">
+                            {isOwner ? (
+                              <>
+                                {canShareWorkspace ? (
+                                  <WorkspaceSharingDialog
+                                    workspace={workspace}
+                                    onOpen={() => setActiveWorkspaceId(workspace.id)}
+                                    onAdded={() => {
+                                      setActiveWorkspaceId(workspace.id)
+                                      setMembersVersion((version) => version + 1)
+                                    }}
+                                  />
+                                ) : (
+                                  <Button variant="outline" size="sm" onClick={() => { setActiveWorkspaceId(workspace.id); openBillingTab() }}>Share</Button>
+                                )}
+                                <Button variant="destructive" size="sm" onClick={() => setWorkspaceToDelete(workspace)}>Delete</Button>
+                              </>
+                            ) : null}
+                          </div>
+                        </div>
                       </li>
                     )
                   })}
@@ -511,8 +532,7 @@ function CloudWorkspacesPanel() {
         <WorkspaceDetailsPanel
           key={activeWorkspace.id}
           workspace={activeWorkspace}
-          onUpgrade={openBillingTab}
-          onDelete={() => setWorkspaceToDelete(activeWorkspace)}
+          refreshKey={membersVersion}
         />
       ) : null}
       <WorkspaceDeletionDialog

--- a/frontend/src/components/runtz/workspace-details-panel.tsx
+++ b/frontend/src/components/runtz/workspace-details-panel.tsx
@@ -1,17 +1,13 @@
 "use client"
 
 import * as React from "react"
-import { LockKeyholeIcon, RefreshCcwIcon, Trash2Icon, UsersIcon } from "lucide-react"
 
 import { useWorkspace } from "@/components/runtz/workspace-context"
-import { WorkspaceSharingDialog } from "@/components/runtz/workspace-sharing-dialog"
-import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@/components/ui/empty"
 import { FieldError } from "@/components/ui/field"
-import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { apiRequest, type Workspace } from "@/lib/api"
 
@@ -24,16 +20,13 @@ type WorkspaceMember = {
 
 export function WorkspaceDetailsPanel({
   workspace,
-  onDelete,
-  onUpgrade,
+  refreshKey,
 }: {
   workspace: Workspace
-  onDelete: () => void
-  onUpgrade: () => void
+  refreshKey: number
 }) {
-  const { currentUser, entitlement } = useWorkspace()
+  const { currentUser } = useWorkspace()
   const isOwner = workspace.createdBy === currentUser.id
-  const canShare = entitlement.plan === "pro" || entitlement.plan === "enterprise"
   const [members, setMembers] = React.useState<WorkspaceMember[]>([])
   const [loading, setLoading] = React.useState(true)
   const [loadError, setLoadError] = React.useState("")
@@ -59,7 +52,7 @@ export function WorkspaceDetailsPanel({
     const controller = new AbortController()
     void loadMembers(controller.signal)
     return () => controller.abort()
-  }, [loadMembers])
+  }, [loadMembers, refreshKey])
 
   async function removeMember(member: WorkspaceMember) {
     if (removingId) return
@@ -84,70 +77,24 @@ export function WorkspaceDetailsPanel({
   return (
     <section id="workspace-details" aria-labelledby={`workspace-title-${workspace.id}`}>
       <Card>
-        <CardHeader className="gap-4 sm:flex sm:items-center sm:justify-between">
-          <div className="flex min-w-0 flex-col gap-1.5">
-            <p className="text-xs font-medium text-muted-foreground">Workspace details</p>
-            <div className="flex min-w-0 flex-wrap items-center gap-2">
-              <CardTitle><h2 id={`workspace-title-${workspace.id}`} className="break-all">{workspace.name}</h2></CardTitle>
-              <Badge variant="outline">{isOwner ? "Owner" : "Shared"}</Badge>
-            </div>
-            <CardDescription>{isOwner ? "Manage your workspace and the people with access." : "A shared workspace you belong to."}</CardDescription>
-          </div>
-          {isOwner ? (
-            <div className="shrink-0 self-start sm:self-center">
-              {canShare ? (
-                <WorkspaceSharingDialog workspace={workspace} disabled={Boolean(removingId)} onAdded={(email) => {
-                  setError("")
-                  setMessage(`Access granted to ${email}.`)
-                  void loadMembers()
-                }} />
-              ) : (
-                <Button variant="outline" onClick={onUpgrade}>
-                  <LockKeyholeIcon data-icon="inline-start" />
-                  Upgrade to add members
-                </Button>
-              )}
-            </div>
-          ) : null}
+        <CardHeader>
+          <CardTitle>
+            <h2 id={`workspace-title-${workspace.id}`} className="break-words">
+              Members <span className="font-normal text-muted-foreground">· {workspace.name}</span>
+            </h2>
+          </CardTitle>
         </CardHeader>
-        <Separator />
-        <CardContent className="grid gap-6 lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-8">
-          <section aria-label="Workspace information" className="flex min-w-0 flex-col gap-4 lg:border-r lg:pr-8">
-            <h3 className="text-sm font-medium">Overview</h3>
-            <dl className="grid grid-cols-2 gap-x-4 gap-y-5 lg:grid-cols-1">
-              <div className="min-w-0">
-                <dt className="text-xs text-muted-foreground">Slug</dt>
-                <dd className="mt-1.5 break-all text-sm">{workspace.slug}</dd>
-              </div>
-              <div>
-                <dt className="text-xs text-muted-foreground">Created</dt>
-                <dd className="mt-1.5 text-sm">{new Intl.DateTimeFormat("en-US", { dateStyle: "medium" }).format(new Date(workspace.createdAt))}</dd>
-              </div>
-              <div>
-                <dt className="text-xs text-muted-foreground">Your access</dt>
-                <dd className="mt-1.5 text-sm">{isOwner ? "Workspace owner" : "Workspace member"}</dd>
-              </div>
-              <div>
-                <dt className="text-xs text-muted-foreground">Members</dt>
-                <dd className="mt-1.5 text-sm">{loading ? <Skeleton className="h-5 w-8" /> : loadError ? "Unavailable" : members.length}</dd>
-              </div>
-            </dl>
-          </section>
-          <section aria-label="Workspace members" className="flex min-w-0 flex-col gap-4">
-            <div>
-              <h3 className="flex items-center gap-2 text-sm font-medium"><UsersIcon className="size-4 text-muted-foreground" />Members</h3>
-              <p className="mt-1 text-sm text-muted-foreground">Members can view scans and manage workspace API keys.</p>
-            </div>
+        <CardContent className="flex min-w-0 flex-col gap-4">
             {message ? <p role="status" className="break-words text-sm text-muted-foreground">{message}</p> : null}
             {error ? <FieldError role="alert">{error}</FieldError> : null}
             {loading ? (
               <div aria-label="Loading members" className="flex flex-col gap-4">
-                {[0, 1].map((item) => <div key={item} className="flex items-center gap-3"><Skeleton className="size-8 rounded-full" /><Skeleton className="h-9 w-48 max-w-full" /></div>)}
+                {[0, 1].map((item) => <div key={item} className="flex items-center gap-3"><Skeleton className="h-9 w-48 max-w-full" /></div>)}
               </div>
             ) : loadError ? (
               <div className="flex flex-col items-start gap-3">
                 <FieldError role="alert">{loadError}</FieldError>
-                <Button variant="outline" size="sm" onClick={() => void loadMembers()}><RefreshCcwIcon data-icon="inline-start" />Retry</Button>
+                <Button variant="outline" size="sm" onClick={() => void loadMembers()}>Retry</Button>
               </div>
             ) : sortedMembers.length === 0 ? (
               <Empty><EmptyHeader><EmptyTitle>No members to display</EmptyTitle><EmptyDescription>Workspace access will appear here.</EmptyDescription></EmptyHeader></Empty>
@@ -155,7 +102,6 @@ export function WorkspaceDetailsPanel({
               <ul className="flex flex-col divide-y divide-border">
                 {sortedMembers.map((member) => (
                   <li key={member.id} className="flex items-center gap-3 py-3 first:pt-0 last:pb-0">
-                    <Avatar><AvatarFallback>{(member.name || member.email).slice(0, 2).toUpperCase()}</AvatarFallback></Avatar>
                     <div className="min-w-0 flex-1">
                       <p className="truncate text-sm font-medium" title={member.name || member.email}>{member.name || member.email}{member.id === currentUser.id ? <span className="ml-1 font-normal text-muted-foreground">(you)</span> : null}</p>
                       <p className="truncate text-xs text-muted-foreground" title={member.email}>{member.email}</p>
@@ -170,15 +116,7 @@ export function WorkspaceDetailsPanel({
                 ))}
               </ul>
             )}
-            {!isOwner ? <p className="text-xs text-muted-foreground">Only the workspace owner can add or remove members.</p> : null}
-          </section>
         </CardContent>
-        {isOwner ? (
-          <CardFooter className="flex-col items-start justify-between gap-3 sm:flex-row sm:items-center">
-            <p className="text-xs text-muted-foreground">Deleting this workspace permanently removes its scans and API keys.</p>
-            <Button variant="destructive" size="sm" disabled={Boolean(removingId)} onClick={onDelete}><Trash2Icon data-icon="inline-start" />Delete workspace</Button>
-          </CardFooter>
-        ) : null}
       </Card>
     </section>
   )

--- a/frontend/src/components/runtz/workspace-sharing-dialog.tsx
+++ b/frontend/src/components/runtz/workspace-sharing-dialog.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import * as React from "react"
-import { UserPlusIcon } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
@@ -12,10 +11,12 @@ import { apiRequest, type Workspace } from "@/lib/api"
 export function WorkspaceSharingDialog({
   workspace,
   onAdded,
+  onOpen,
   disabled = false,
 }: {
   workspace: Workspace
   onAdded: (email: string) => void
+  onOpen: () => void
   disabled?: boolean
 }) {
   const [open, setOpen] = React.useState(false)
@@ -26,6 +27,7 @@ export function WorkspaceSharingDialog({
   function handleOpenChange(nextOpen: boolean) {
     if (pending) return
     setOpen(nextOpen)
+    if (nextOpen) onOpen()
     setEmail("")
     setError("")
   }
@@ -53,9 +55,8 @@ export function WorkspaceSharingDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogTrigger render={<Button disabled={disabled} />}>
-        <UserPlusIcon data-icon="inline-start" />
-        Add member
+      <DialogTrigger render={<Button variant="outline" size="sm" disabled={disabled} />}>
+        Share
       </DialogTrigger>
       <DialogContent className="sm:max-w-md" showCloseButton={!pending}>
         <DialogHeader>


### PR DESCRIPTION
## What does this PR do?

Restore Share and Delete to each owned workspace row while preserving the selected-row highlight. Remove folder icons and selection arrows. The lower panel now contains only the selected workspace's member list, roles and access removal; overview metadata, avatars, extra descriptions and the deletion footer are removed.

Share opens the existing email-only form for the correct workspace and refreshes its member list after a successful addition. Free accounts retain the billing upgrade path and shared workspaces retain read-only member management.

## Base branch

- [x] This PR targets `dev`

## Checklist

- [x] Backend unchanged; Go tests and vet passed for the existing backend in this session
- [x] `cd frontend && npm run lint && npm run build` passes
- [x] No Helm changes; chart lint not applicable
- [x] No secrets, tokens or personal endpoints in the diff
- [x] Docs updated

## Generated by

- **Author:** Codex (GPT-6)
- **Task / prompt:** Remove workspace icons and arrows, restore Share/Delete to workspace rows, keep the lower panel minimal with only members, and publish to dev at the user's request.
- **How it was verified:** Frontend lint and production build. Playwright checked row actions, target selection, member refresh, errors/retry, keyboard focus, permissions and overflow for Pro at 375px, Enterprise at 768px and 1900px, Pro/light at 1440px and Free at 375px. Desktop and mobile screenshots reviewed.
- [ ] A human reviewed the full diff and takes responsibility for it

By submitting this pull request, I agree that my contribution is provided under the project license (BUSL-1.1) as described in CONTRIBUTING.md.
